### PR TITLE
fix(api): support structured outputs for OpenAI-compatible providers

### DIFF
--- a/packages/api/src/extensions/actions/ai/ai-base.action.spec.ts
+++ b/packages/api/src/extensions/actions/ai/ai-base.action.spec.ts
@@ -198,14 +198,15 @@ describe('AiBaseAction', () => {
   describe('buildProviderInitOptions', () => {
     it('returns init options when provided', () => {
       const options = action.buildProviderInitOptionsPublic(
-        'custom',
+        'litellm',
         {
           settings: {
             api_key: 'key',
             base_url: 'https://example.com',
             organization: 'org',
-            provider: 'openai',
-            model_id: 'gpt-4o-mini',
+            provider: 'litellm',
+            model_id: 'gemini-2.5-flash',
+            supports_structured_outputs: true,
           },
         } as RuntimeBindings['model'],
         'key',
@@ -215,7 +216,41 @@ describe('AiBaseAction', () => {
         apiKey: 'key',
         baseURL: 'https://example.com',
         organization: 'org',
+        supportsStructuredOutputs: true,
       });
+    });
+
+    it('leaves supportsStructuredOutputs undefined when not configured', () => {
+      const options = action.buildProviderInitOptionsPublic(
+        'litellm',
+        {
+          settings: {
+            api_key: 'key',
+            provider: 'litellm',
+            model_id: 'gemini-2.5-flash',
+          },
+        } as RuntimeBindings['model'],
+        'key',
+      );
+
+      expect(options.supportsStructuredOutputs).toBeUndefined();
+    });
+
+    it('preserves explicitly disabled structured outputs', () => {
+      const options = action.buildProviderInitOptionsPublic(
+        'litellm',
+        {
+          settings: {
+            api_key: 'key',
+            provider: 'litellm',
+            model_id: 'gemini-2.5-flash',
+            supports_structured_outputs: false,
+          },
+        } as RuntimeBindings['model'],
+        'key',
+      );
+
+      expect(options).toHaveProperty('supportsStructuredOutputs', false);
     });
 
     it('throws when api key is required but missing', () => {
@@ -275,6 +310,7 @@ describe('AiBaseAction', () => {
       const options: ProviderInitOptions = {
         apiKey: 'sk-litellm-key',
         baseURL: 'http://localhost:4000/v1',
+        supportsStructuredOutputs: false,
       };
 
       (createOpenAICompatible as jest.Mock).mockReturnValue(provider);

--- a/packages/api/src/extensions/actions/ai/ai-base.action.ts
+++ b/packages/api/src/extensions/actions/ai/ai-base.action.ts
@@ -40,6 +40,7 @@ export type ProviderInitOptions = {
   apiKey?: string;
   baseURL?: string;
   organization?: string;
+  supportsStructuredOutputs?: boolean;
 };
 
 export type LanguageModelProvider =
@@ -93,6 +94,8 @@ export abstract class AiBaseAction<
     const apiKey = modelSettings?.api_key;
     const baseURL = modelSettings?.base_url;
     const organization = modelSettings?.organization;
+    const supportsStructuredOutputs =
+      modelSettings?.supports_structured_outputs;
 
     if (!apiKey && this.shouldRequireApiKey(providerId)) {
       throw new Error(
@@ -104,6 +107,7 @@ export abstract class AiBaseAction<
       apiKey: credentials,
       baseURL,
       organization,
+      supportsStructuredOutputs,
     };
   }
 
@@ -338,6 +342,7 @@ export abstract class AiBaseAction<
       'api_key',
       'base_url',
       'organization',
+      'supports_structured_outputs',
     ] as const;
 
     if (!this.isPlainObject(value) || !this.isPlainObject(value.settings)) {

--- a/packages/api/src/extensions/actions/ai/model.binding.ts
+++ b/packages/api/src/extensions/actions/ai/model.binding.ts
@@ -60,6 +60,21 @@ export const aiModelBindingSchema = z.strictObject({
         hideUntilAdded: true,
       },
     }),
+  supports_structured_outputs: z
+    .boolean()
+    .optional()
+    .meta({
+      title: 'Supports Structured Outputs',
+      description:
+        'Enable for endpoints that support response_format: json_schema. This sends the full JSON schema for structured generation. Leave unset to preserve the provider default.',
+      'ui:options': {
+        showWhen: {
+          field: 'provider',
+          in: ['litellm', 'openai-compatible'],
+        },
+        hideUntilAdded: true,
+      },
+    }),
 });
 
 declare global {

--- a/packages/api/src/extensions/actions/ai/model.binding.ts
+++ b/packages/api/src/extensions/actions/ai/model.binding.ts
@@ -70,7 +70,7 @@ export const aiModelBindingSchema = z.strictObject({
       'ui:options': {
         showWhen: {
           field: 'provider',
-          in: ['litellm', 'openai-compatible'],
+          in: ['gateway', 'litellm', 'openai-compatible'],
         },
         hideUntilAdded: true,
       },


### PR DESCRIPTION
## Screenshot
<img width="642" height="197" alt="image" src="https://github.com/user-attachments/assets/8459952c-e250-421c-acfb-eaee09b3cf58" />

## Summary
Added an optional `supports_structured_outputs` model-binding setting for LiteLLM and OpenAI-compatible providers. The setting is forwarded to the AI SDK as `supportsStructuredOutputs`.

## Why
OpenAI-compatible providers default structured-output support to `false`, causing JSON schemas to be omitted from requests. This makes structured generation unreliable for compatible endpoints that support `response_format: json_schema` and resolves #2192.

## How to review
Focus on:

- The new optional field in `model.binding.ts`.
- The snake_case-to-camelCase mapping in `AiBaseAction.buildProviderInitOptions`.
- Coverage of enabled, disabled, and undefined configurations in `ai-base.action.spec.ts`.

## Validation
- Targeted AI base-action tests: 41 passed.
- API TypeScript typecheck passed.
- API lint passed.
- API production build passed.
- `git diff --check` passed.