### PR TITLE
fix(frontend): keep workflow output on latest task

### DIFF
--- a/packages/frontend/src/components/visual-editor/v4/components/main/ActionDrawer/ActionFormDrawer/useActionFormDrawerController.ts
+++ b/packages/frontend/src/components/visual-editor/v4/components/main/ActionDrawer/ActionFormDrawer/useActionFormDrawerController.ts
@@ -399,11 +399,10 @@ export const useActionFormDrawerController = ({
           ...(currentDefinition.defs ?? {}),
           [nextTaskName]: nextTask,
         },
-        outputs:
-          currentDefinition.outputs &&
-          Object.keys(currentDefinition.outputs).length > 0
-            ? currentDefinition.outputs
-            : { result: `=$output.${nextTaskName}` },
+        outputs: {
+          ...currentDefinition.outputs,
+          result: `=$output.${nextTaskName}`,
+        },
       };
       const insertedDefinition = target.insertPath
         ? WorkflowHelper.insertStepAtPath(

--- a/packages/frontend/src/components/visual-editor/v4/providers/WorkflowProvider.tsx
+++ b/packages/frontend/src/components/visual-editor/v4/providers/WorkflowProvider.tsx
@@ -139,10 +139,10 @@ export const WorkflowProvider: React.FC<WorkflowContextProps> = ({
         ...baseDefinition.defs,
         [nextTaskName]: nextTaskDefinition,
       };
-      const nextOutputs =
-        baseDefinition.outputs && Object.keys(baseDefinition.outputs).length > 0
-          ? baseDefinition.outputs
-          : { result: `=$output.${nextTaskName}` };
+      const nextOutputs = {
+        ...baseDefinition.outputs,
+        result: `=$output.${nextTaskName}`,
+      };
       const nextStep: FlowStep = { do: nextTaskName };
       const definitionWithTask: WorkflowDefinition = {
         ...baseDefinition,
@@ -297,7 +297,17 @@ export const WorkflowProvider: React.FC<WorkflowContextProps> = ({
         return;
       }
 
-      updateDefinitionState(nextDefinition);
+      const lastTaskName = Object.keys(
+        extractTaskDefinitions(nextDefinition.defs),
+      ).at(-1);
+      const { result: _result, ...outputs } = nextDefinition.outputs;
+
+      updateDefinitionState({
+        ...nextDefinition,
+        outputs: lastTaskName
+          ? { ...outputs, result: `=$output.${lastTaskName}` }
+          : outputs,
+      });
 
       if (!nodeId || !selectedNodeIds.includes(nodeId)) {
         return;


### PR DESCRIPTION
## Summary
Updated workflow YAML output references so `outputs.result` points to the latest task when adding or removing action nodes. Other named outputs remain unchanged.

## Why
Workflow edits could leave `outputs.result` referencing a removed or outdated task, producing invalid YAML references and incorrect workflow results.

## How to review
Focus on:
- Action creation in `useActionFormDrawerController.ts`.
- Action addition and node removal in `WorkflowProvider.tsx`.
- Preservation of outputs other than `result`.
- Behavior when removing the final remaining task.

## Validation
- Frontend TypeScript typecheck passed.
- ESLint and pre-commit checks passed.
- `git diff --check` passed.