### PR TITLE
refactor(frontend): centralize action step insertion

### DIFF
--- a/packages/frontend/src/components/visual-editor/v4/components/main/ActionDrawer/ActionFormDrawer/useActionFormDrawerController.ts
+++ b/packages/frontend/src/components/visual-editor/v4/components/main/ActionDrawer/ActionFormDrawer/useActionFormDrawerController.ts
@@ -8,7 +8,6 @@ import {
   BaseSettingsSchema,
   DEFAULT_RETRY_SETTINGS,
   DEFAULT_TIMEOUT_MS,
-  FlowStep,
   JsonValue,
   Settings,
   TaskDefinition,
@@ -135,6 +134,7 @@ export const useActionFormDrawerController = ({
   const {
     workflow,
     definition,
+    addActionStep,
     updateDefinitionState,
     isSaving,
     taskDefinitions,
@@ -392,31 +392,8 @@ export const useActionFormDrawerController = ({
           ? { settings: nextSettingsData as TaskDefinition["settings"] }
           : {}),
       };
-      const nextStep: FlowStep = { do: nextTaskName };
-      const definitionWithTask: WorkflowDefinition = {
-        ...currentDefinition,
-        defs: {
-          ...(currentDefinition.defs ?? {}),
-          [nextTaskName]: nextTask,
-        },
-        outputs: {
-          ...currentDefinition.outputs,
-          result: `=$output.${nextTaskName}`,
-        },
-      };
-      const insertedDefinition = target.insertPath
-        ? WorkflowHelper.insertStepAtPath(
-            definitionWithTask,
-            target.insertPath,
-            nextStep,
-          )
-        : null;
-      const nextDefinition: WorkflowDefinition = insertedDefinition ?? {
-        ...definitionWithTask,
-        flow: [...(currentDefinition.flow ?? []), nextStep],
-      };
 
-      updateDefinitionState(nextDefinition);
+      addActionStep(nextTaskName, nextTask, target.insertPath);
       handleSaveClose();
 
       return;

--- a/packages/frontend/src/components/visual-editor/v4/providers/WorkflowProvider.tsx
+++ b/packages/frontend/src/components/visual-editor/v4/providers/WorkflowProvider.tsx
@@ -20,7 +20,6 @@ import type { WorkflowImportResult } from "@hexabot-ai/types";
 import debounce from "@mui/utils/debounce";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
-import { getSchemaDefaults } from "@/app-components/inputs/JsonSchemaForm";
 import { useFind } from "@/hooks/crud/useFind";
 import { useGetFromCache } from "@/hooks/crud/useGet";
 import {
@@ -36,17 +35,13 @@ import { useToast } from "@/hooks/useToast";
 import { useTranslate } from "@/hooks/useTranslate";
 import type { WorkflowExportFile } from "@/services/api.class";
 import { EntityType, Format, QueryType, RouterType } from "@/services/types";
-import type { IAction } from "@/types/action.types";
 import type { EntityAttributes } from "@/types/base.types";
 
 import { WorkflowContext } from "../contexts/workflow.context";
 import { useWorkflowDefinitionState } from "../hooks/useWorkflowDefinitionState";
 import type { WorkflowContextProps } from "../types/workflow.types";
-import { createUniqueDefinitionName } from "../utils/definition-name.utils";
 import { createBaseDefinition } from "../utils/workflow-definition.utils";
 
-type TaskInputs = NonNullable<TaskDefinition["inputs"]>;
-type TaskSettings = NonNullable<TaskDefinition["settings"]>;
 type WorkflowAttributes = EntityAttributes<EntityType.WORKFLOW>;
 const EMPTY_GRAPH_SELECTION: WorkflowSelectionSnapshot = {
   nodeIds: [],
@@ -116,38 +111,17 @@ export const WorkflowProvider: React.FC<WorkflowContextProps> = ({
     [definition?.defs],
   );
   const addActionStep = useCallback(
-    (action: IAction, insertPath?: FlowStepPath | null) => {
+    (
+      taskName: string,
+      taskDefinition: TaskDefinition,
+      insertPath?: FlowStepPath | null,
+    ) => {
       const baseDefinition = definition ?? createBaseDefinition();
-      const nextTaskName = createUniqueDefinitionName(
-        action.name,
-        baseDefinition.defs ?? {},
-        "new_task",
-      );
-      const taskDescription = action.description?.trim();
-      const inputDefaults = getSchemaDefaults<TaskInputs>(action.inputSchema);
-      const settingDefaults = getSchemaDefaults<TaskSettings>(
-        action.settingSchema,
-      )!;
-      const nextTaskDefinition: TaskDefinition = {
-        kind: "task",
-        action: action.name,
-        ...(taskDescription ? { description: taskDescription } : {}),
-        ...(inputDefaults !== undefined ? { inputs: inputDefaults } : {}),
-        ...(settingDefaults !== undefined ? { settings: settingDefaults } : {}),
-      };
-      const nextDefs = {
-        ...baseDefinition.defs,
-        [nextTaskName]: nextTaskDefinition,
-      };
-      const nextOutputs = {
-        ...baseDefinition.outputs,
-        result: `=$output.${nextTaskName}`,
-      };
-      const nextStep: FlowStep = { do: nextTaskName };
+      const nextStep: FlowStep = { do: taskName };
       const definitionWithTask: WorkflowDefinition = {
         ...baseDefinition,
-        defs: nextDefs,
-        outputs: nextOutputs,
+        defs: { ...baseDefinition.defs, [taskName]: taskDefinition },
+        outputs: { ...baseDefinition.outputs, result: `=$output.${taskName}` },
       };
       const insertedDefinition = insertPath
         ? WorkflowHelper.insertStepAtPath(

--- a/packages/frontend/src/components/visual-editor/v4/types/workflow.types.ts
+++ b/packages/frontend/src/components/visual-editor/v4/types/workflow.types.ts
@@ -22,7 +22,6 @@ import type { ResizeControlDirection } from "@xyflow/system";
 import type { Dispatch, ReactNode, SetStateAction } from "react";
 
 import { EntityType } from "@/services/types";
-import type { IAction } from "@/types/action.types";
 import type { EntityAttributes } from "@/types/base.types";
 
 import type { UpdateWorkflowDefinitionStateOptions } from "../utils/workflow-definition-state.utils";
@@ -105,7 +104,11 @@ export interface IWorkflowContext {
   isImportingWorkflow: boolean;
   exportWorkflow: (workflowId: string) => void;
   importWorkflowBundle: (file: File) => void;
-  addActionStep: (action: IAction, insertPath?: FlowStepPath | null) => void;
+  addActionStep: (
+    taskName: string,
+    taskDefinition: TaskDefinition,
+    insertPath?: FlowStepPath | null,
+  ) => void;
   addConditionalStep: (insertPath?: FlowStepPath | null) => void;
   addLoopStep: (insertPath?: FlowStepPath | null) => void;
   addParallelStep: (insertPath?: FlowStepPath | null) => void;


### PR DESCRIPTION
## Summary
Refactored action creation so `ActionFormDrawer` prepares and validates the task while `addActionStep` centrally handles adding it to the workflow definition, flow, and outputs. Removed duplicated insertion and default-generation logic.

## Why
Task insertion logic was duplicated between the form controller and workflow provider, increasing maintenance overhead and the risk of inconsistent behavior. The refactor reduces the implementation by 46 lines while preserving configured inputs, settings, descriptions, and execution overrides.

## How to review
Focus on:

- The updated `addActionStep` signature and insertion logic in `WorkflowProvider.tsx`.
- The create path in `useActionFormDrawerController.ts`.
- Preservation of edited task values and insertion paths.
- Confirming that the edit path continues to preserve existing output references.

## Validation
- Frontend ESLint passed.
- Frontend TypeScript typecheck passed.
- `git diff --check` passed.