### PR TITLE
feat(widget): bundle React and ship a self-contained config() embed API

### DIFF
--- a/packages/widget/AGENTS.md
+++ b/packages/widget/AGENTS.md
@@ -11,7 +11,8 @@ Typical agent work in this package includes:
 
 ## Repository Structure
 Key paths in `packages/widget`:
-- `src/ChatWidget.tsx`: Main exported widget entry (also Vite library entry).
+- `src/embed.tsx`: Vite library entry and public package surface (`config`, `ChatWidget`).
+- `src/ChatWidget.tsx`: Main widget component, composed by `src/embed.tsx`.
 - `src/UiChatWidget.tsx`: Alternate/customizable widget composition entry.
 - `src/main.tsx`: Local dev/demo app entry for Vite.
 - `src/components/`: UI building blocks (chat window, header, messages, launcher, buttons, icons).
@@ -29,7 +30,8 @@ Key paths in `packages/widget`:
 - `eslint.config.cjs` / `eslint.config-staged.cjs`: Lint rules.
 - `.prettierrc`: Formatting defaults.
 - `tsconfig*.json`: TypeScript config.
-- `vite.config.ts`: Library bundling and externals config.
+- `vite.config.ts`: Library bundling, declaration emit, and asset precompression.
+- `tsconfig.build.json`: Declaration-emit config (`tsconfig.app.json` sets `noEmit`).
 - `Dockerfile`: Containerized build/dev/serve flow.
 
 ## Setup & Dev Environment
@@ -86,8 +88,12 @@ pnpm --filter @hexabot-ai/widget run build
 Unit tests:
 - Vitest is configured in `vite.config.ts` under `test`.
 - Current widget tests live in:
-  - `src/theme/theme.utils.test.ts`
+  - `src/components/Message.test.tsx`
+  - `src/providers/ConfigProvider.test.tsx`
   - `src/providers/ThemeProvider.test.tsx`
+  - `src/theme/theme.utils.test.ts`
+  - `src/utils/SocketIoClient.test.ts`
+  - `src/utils/webhook-url.test.ts`
 - Test setup is initialized in `src/test/setup.ts`.
 
 ## Coding Style & Conventions
@@ -180,8 +186,16 @@ Release (v3 alpha train, `main` branch):
   - `packages/widget/node_modules/**`
   - `packages/widget/.turbo/**`
 - Keep the public widget entry contract stable unless explicitly requested:
-  - `src/ChatWidget.tsx` default export.
+  - `config(options)` exported from `src/embed.tsx` — this is what embedders call. `options` merges the mount target (`id`, `css`, `shadowDom`) with the widget config into one object.
   - Vite library build target in `vite.config.ts` (`name: "HexabotWidget"`).
+- React and React DOM are **bundled**, not externalized, and are declared as
+  `devDependencies` rather than peers. React 19 ships no UMD builds, so a
+  script-tag embedder cannot supply them. Do not re-add them to `dependencies`
+  or add `react` to `rolldownOptions.external`; either change reintroduces a
+  hard dependency on the host page's React version.
+- `process.env.NODE_ENV` is pinned to `production` only for production builds.
+  Pinning it unconditionally breaks the test run, because React's production
+  build omits `act`.
 - Settings persistence is now instance-scoped (`hexabot:widget:settings:<scope>`); avoid changes that re-introduce cross-widget leakage.
 - Any protocol-level changes (socket payloads, webhook behavior) must stay compatible with the backend expectations used in `src/providers/ChatProvider.tsx` and `src/utils/SocketIoClient.ts`.
 - Preserve license headers and do not remove licensing notices.

--- a/packages/widget/README.md
+++ b/packages/widget/README.md
@@ -57,76 +57,83 @@ pnpm --filter @hexabot-ai/widget run preview
 
 The preview server is helpful for validating the compiled assets before publishing.
 
+### Serve the Bundle
+
+```bash
+pnpm --filter @hexabot-ai/widget run serve
+```
+
+Unlike `preview`, this serves the precompressed `.br`/`.gz` files the build
+produces alongside the bundle — use it to check what a CDN or self-hosted
+deployment will actually send over the wire. Both commands default to port
+`5174`, so run only one at a time.
+
 ## Embed Chat Widget
 
 Once the widget is built, you can easily embed it into any webpage. Here's an example of how to add it to your website:
 
+The widget bundles its own copy of React, so `hexabot-widget.umd.js` is the
+only *script* you need — no separate React/ReactDOM tags to load first. Its
+styles still ship as a separate file, so keep the stylesheet link.
+
 ```html
-<script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
-<script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
 <link rel="stylesheet" href="<<WIDGET URL>>/style.css">
 <script src="<<WIDGET URL>>/hexabot-widget.umd.js"></script>
 
 <div id="hb-chat-widget"></div>
 <script>
-  const el = React.createElement;
-  const domContainer = document.getElementById('hb-chat-widget');
-  ReactDOM.render(
-    el(HexabotWidget, {
-      apiUrl: 'https://api.yourdomain.com',
-      channel: 'web',
-      sourceId: 'your-source-id',
-      transport: 'ws', // or "polling"
-      primaryColor: '#1ba089',
-    }),
-    domContainer,
-  );
+  HexabotWidget.config({
+    id: 'hb-chat-widget',
+    apiUrl: 'https://api.yourdomain.com',
+    channel: 'web',
+    sourceId: 'your-source-id',
+    transport: 'ws', // or "polling"
+    primaryColor: '#1ba089',
+  });
 </script>
 ```
+
+`config` takes one object: `id` (an element id, a CSS selector, or an element)
+plus `css` (a stylesheet URL to load) and `shadowDom` (render in a shadow root),
+alongside the regular widget config.
+
+`config` returns a handle with an `unmount()` method if you need to tear the
+widget down again.
 
 Replace the values in `apiUrl`, `sourceId`, and `primaryColor` with your configuration details.
 `transport` is optional and accepts `ws` (default) or `polling`.
 
 To prevent the website css from conflicting with the chat widget css, we can leverage the shadow dom:
 
+Pass `shadowDom: true` and `config` creates the shadow root, renders inside it, and
+loads `css` into that root — a shadow root does not inherit the page's styles,
+so the stylesheet has to go in with it. No `<link>` in the page is needed.
+
 ```html
-<script crossorigin src="https://cdn.jsdelivr.net/npm/react@18/umd/react.production.min.js"></script>
-<script crossorigin src="https://cdn.jsdelivr.net/npm/react-dom@18/umd/react-dom.production.min.js"></script>
 <script src="<<WIDGET URL>>/hexabot-widget.umd.js"></script>
 
 <div id="hb-chat-widget"></div>
 <script>
-  // Create the shadow root and attach it to the widget container
-  const createElement = (tag, props = {}) => Object.assign(document.createElement(tag), props);
-  const shadowContainer = createElement("div");
-  document
-      .getElementById('hb-chat-widget')
-      .attachShadow({ mode: 'open' })
-      .append(
-        shadowContainer,
-        createElement("link", {
-          rel: "stylesheet",
-          href: "<<WIDGET URL>>/style.css"
-        }),
-      );
-
-  // Render the widget inside the shadow root
-  ReactDOM.render(
-    React.createElement(HexabotWidget, {
-      apiUrl: 'https://api.yourdomain.com',
-      channel: 'web',
-      sourceId: 'your-source-id',
-      transport: 'ws', // or "polling"
-      primaryColor: '#1ba089',
-    }),
-    shadowContainer,
-  );
+  HexabotWidget.config({
+    id: 'hb-chat-widget',
+    apiUrl: 'https://api.yourdomain.com',
+    channel: 'web',
+    sourceId: 'your-source-id',
+    transport: 'ws', // or "polling"
+    primaryColor: '#1ba089',
+    css: '<<WIDGET URL>>/style.css',
+    shadowDom: true,
+  });
 </script>
 ```
 
-
-For stable v3 releases, pin the major version:
+For stable releases, pin the major version:
 `https://cdn.jsdelivr.net/npm/@hexabot-ai/widget@3/dist/`
+
+> **Note:** the snippets above use `HexabotWidget.config()`, which is only
+> available from the major release that bundles React. Pinning `@3` loads the
+> older bundle, which instead expects `React` and `ReactDOM` globals to already
+> be on the page. Bump this pin when that major is published.
 
 JsDelivr uses the package published in the npm registry: https://www.npmjs.com/package/@hexabot-ai/widget
 

--- a/packages/widget/package.json
+++ b/packages/widget/package.json
@@ -6,14 +6,21 @@
   "license": "FCL-1.0-ALv2",
   "type": "module",
   "main": "dist/hexabot-widget.umd.js",
+  "module": "dist/hexabot-widget.es.js",
+  "types": "dist/embed.d.ts",
   "style": "dist/style.css",
+  "files": [
+    "dist",
+    "src",
+    "README.md"
+  ],
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "pnpm run clean && tsc && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "lint:fix": "eslint . --ext ts,tsx --fix",
-    "preview": "vite preview",
-    "serve": "pnpm exec http-server ./dist/",
+    "preview": "vite preview --port 5174",
+    "serve": "pnpm exec http-server ./dist/ -b -g -p 5174",
     "test": "vitest run",
     "typecheck": "tsc --noEmit",
     "format": "pnpm run lint:fix",
@@ -30,8 +37,6 @@
     "lucide-react": "^0.562.0",
     "marked": "14.0.0",
     "normalize.css": "^8.0.1",
-    "react": "^19.2.7",
-    "react-dom": "^19.2.7",
     "socket.io-client": "^4.8.1"
   },
   "devDependencies": {
@@ -51,6 +56,8 @@
     "http-server": "^14.1.1",
     "jsdom": "^28.0.0",
     "lint-staged": "^15.3.0",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
     "rimraf": "^6.0.1",
     "sass": "^1.98.0",
     "typescript": "^5.8.3",

--- a/packages/widget/public/index.html
+++ b/packages/widget/public/index.html
@@ -1,45 +1,24 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Widget Embed</title>
-    <script
-      crossorigin
-      src="https://unpkg.com/react@18/umd/react.production.min.js"
-    ></script>
-    <script
-      crossorigin
-      src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"
-    ></script>
     <script src="./hexabot-widget.umd.js"></script>
   </head>
   <body>
     <div id="hb-chat-widget"></div>
     <script>
-      // Create the shadow root and attach it to the widget container
-      const createElement = (tag, props = {}) =>
-        Object.assign(document.createElement(tag), props);
-      const shadowContainer = createElement("div");
-      document
-        .getElementById("hb-chat-widget")
-        .attachShadow({ mode: "open" })
-        .append(
-          shadowContainer,
-          createElement("link", {
-            rel: "stylesheet",
-            href: "./style.css",
-          }),
-        );
-      ReactDOM.render(
-        React.createElement(HexabotWidget, {
-          apiUrl: "http://localhost:4000",
-          channel: "web",
-          token: "token123",
-          primaryColor: "#1ba089",
-        }),
-        shadowContainer,
-      );
+      HexabotWidget.config({
+        id: "hb-chat-widget",
+        css: "./style.css",
+        shadowDom: true,
+        apiUrl: "http://localhost:3000",
+        channel: "web",
+        sourceId: "replace-with-source-id",
+        language: "en",
+        primaryColor: "#29998e",
+      });
     </script>
   </body>
 </html>

--- a/packages/widget/src/embed.tsx
+++ b/packages/widget/src/embed.tsx
@@ -1,0 +1,85 @@
+/*
+ * Hexabot — Fair Core License (FCL-1.0-ALv2)
+ * Copyright (c) 2025 Hexastack.
+ * Full terms: see LICENSE.md.
+ */
+
+import { createRoot, type Root } from "react-dom/client";
+
+import ChatWidget from "./ChatWidget";
+import { Config } from "./types/config.types";
+
+/**
+ * React is bundled here, so embedders have no `React`/`ReactDOM` global to
+ * render with. `config` owns the root and hides the widget's React version.
+ */
+
+// Re-mounting must reuse the container's root; `createRoot` twice throws.
+const roots = new WeakMap<Element, Root>();
+
+export type MountHandle = {
+  /** Unmounts the widget and releases its React root. */
+  unmount: () => void;
+};
+
+export type ConfigOptions = Partial<Config> & {
+  /** Element id, CSS selector, or element to mount into. */
+  id: string | Element;
+  /** Stylesheet URL, loaded into whichever root the widget renders in. */
+  css?: string;
+  /** Render inside a shadow root so the host page's CSS cannot leak in. */
+  shadowDom?: boolean;
+};
+
+export function config({
+  id,
+  css,
+  shadowDom,
+  ...props
+}: ConfigOptions): MountHandle {
+  const host =
+    typeof id === "string"
+      ? (document.getElementById(id) ?? document.querySelector(id))
+      : id;
+
+  if (!host) throw new Error(`Hexabot widget: no element matching "${id}"`);
+
+  // `attachShadow` throws if called twice, so re-mounting reuses the root.
+  const shadowRoot = shadowDom
+    ? (host.shadowRoot ?? host.attachShadow({ mode: "open" }))
+    : null;
+  // A shadow root does not inherit the page's styles, so the link goes inside.
+  const styleTarget = shadowRoot ?? document.head;
+  // Reuses the existing child on re-mount instead of stacking another one.
+  const container =
+    shadowRoot?.querySelector("div") ??
+    shadowRoot?.appendChild(document.createElement("div")) ??
+    host;
+
+  if (css && !styleTarget.querySelector(`link[href="${css}"]`)) {
+    const link = document.createElement("link");
+
+    link.rel = "stylesheet";
+    link.href = css;
+    styleTarget.prepend(link);
+  }
+
+  let root = roots.get(container);
+
+  if (!root) {
+    root = createRoot(container);
+    roots.set(container, root);
+  }
+
+  root.render(<ChatWidget {...props} />);
+
+  return {
+    unmount: () => {
+      root.unmount();
+      roots.delete(container);
+    },
+  };
+}
+
+export { ChatWidget };
+export type { Config };

--- a/packages/widget/src/main.tsx
+++ b/packages/widget/src/main.tsx
@@ -19,7 +19,7 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
         channel: "web",
         sourceId: "replace-with-source-id",
         language: "en",
-        primaryColor: "#1BA089",
+        primaryColor: "#29998e",
       }}
     />
   </React.StrictMode>,

--- a/packages/widget/tsconfig.build.json
+++ b/packages/widget/tsconfig.build.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.app.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "declarationMap": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx", "src/test/**"]
+}

--- a/packages/widget/vite.config.ts
+++ b/packages/widget/vite.config.ts
@@ -4,36 +4,73 @@
  * Full terms: see LICENSE.md.
  */
 
-import { resolve } from "path";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { brotliCompressSync, constants, gzipSync } from "node:zlib";
 
 import react from "@vitejs/plugin-react";
+import type { Plugin } from "vite";
 import dts from "vite-plugin-dts";
 import { defineConfig } from "vitest/config";
 
+/** Emits `.br`/`.gz` siblings for self-hosting. CDNs compress on their own. */
+const precompressAssets = (outDir: string): Plugin => ({
+  name: "hexabot-precompress-assets",
+  apply: "build",
+  closeBundle() {
+    // Only what an embedder loads directly; `.es.js` goes through a bundler.
+    // Runs per output format, so a file a later pass emits is compressed then.
+    for (const name of ["hexabot-widget.umd.js", "style.css"]) {
+      const file = resolve(outDir, name);
+
+      if (!existsSync(file)) continue;
+
+      const source = readFileSync(file);
+      const params = {
+        [constants.BROTLI_PARAM_QUALITY]: 11,
+        [constants.BROTLI_PARAM_SIZE_HINT]: source.length,
+      };
+
+      writeFileSync(`${file}.gz`, gzipSync(source, { level: 9 }));
+      writeFileSync(`${file}.br`, brotliCompressSync(source, { params }));
+    }
+  },
+});
+
 export default defineConfig(({ mode }) => {
   return {
-    plugins: [react(), dts()],
+    plugins: [
+      react(),
+      // tsconfig.app.json sets `noEmit`, which silently drops declarations.
+      dts({ tsconfigPath: "./tsconfig.build.json" }),
+      precompressAssets(resolve(__dirname, "dist")),
+    ],
     server: {
       host: "0.0.0.0",
     },
     define: {
       "process.env":
         mode === "development" ? { "process.env": process.env } : {},
+      // React is bundled, so we pick its flavor; unset ships the dev build.
+      // Production only: vitest shares this config, and React's production
+      // build omits `act`.
+      "process.env.NODE_ENV": JSON.stringify(
+        mode === "production" ? "production" : "development",
+      ),
     },
     build: {
+      // `clean` runs first instead: the umd pass would wipe the es pass's types.
+      emptyOutDir: false,
       lib: {
-        entry: resolve(__dirname, "src/ChatWidget.tsx"),
+        entry: resolve(__dirname, "src/embed.tsx"),
         name: "HexabotWidget",
         fileName: (format) => `hexabot-widget.${format}.js`,
         cssFileName: "style",
       },
+      // React stays bundled: v19 ships no UMD build for a script tag to load.
       rolldownOptions: {
-        external: ["react", "react-dom"],
         output: {
-          globals: {
-            react: "React",
-            "react-dom": "ReactDOM",
-          },
+          exports: "named",
         },
       },
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -890,12 +890,6 @@ importers:
       normalize.css:
         specifier: ^8.0.1
         version: 8.0.1
-      react:
-        specifier: 19.2.7
-        version: 19.2.7
-      react-dom:
-        specifier: 19.2.7
-        version: 19.2.7(react@19.2.7)
       socket.io-client:
         specifier: ^4.8.1
         version: 4.8.1
@@ -948,6 +942,12 @@ importers:
       lint-staged:
         specifier: ^15.3.0
         version: 15.5.2
+      react:
+        specifier: 19.2.7
+        version: 19.2.7
+      react-dom:
+        specifier: 19.2.7
+        version: 19.2.7(react@19.2.7)
       rimraf:
         specifier: ^6.0.1
         version: 6.0.1


### PR DESCRIPTION
## Summary

The widget's build was broken in two independent ways: on `main` already, the `.d.ts` build step was silently emitting zero declaration files and the checked-in demo page used a config shape that would throw at runtime; on top of that, the React 19 migration broke the CDN-script-tag embed pattern outright, since React 19 ships no UMD build. This PR bundles React into the widget, replaces the old `ReactDOM.render` embed snippet with a single self-contained `HexabotWidget.config(...)` call, fixes the declaration build, and ships precompressed `.br`/`.gz` assets for self-hosted deployments.

## Why

**Confirmed broken on `main`, independent of React 19** — built `main`'s widget package in an isolated worktree to verify directly:
- `dts()` logs `Declaration files built in 1671ms` and reports success, but the build emits **zero** `.d.ts` files (`find dist -name "*.d.ts"` → 0). Root cause: `tsconfig.app.json` sets `noEmit: true`, and the `dts()` plugin call had no `tsconfigPath` override, so it inherited that. `package.json` has no `types` field either, so this went unnoticed.
- `main`'s own `public/index.html` demo passes `token: "token123"` — not a field on `Config` — and never sets `sourceId`, which `Config` requires. At runtime this hits `buildWebhookUrl`'s `sourceId.trim()`, which throws on `undefined`. The widget's own shipped demo page cannot run as checked in.

**Additionally broken by the React 19 migration** — React 19 dropped UMD builds entirely, so the "load React/ReactDOM from a CDN, then the widget script" pattern (which worked on `main` against `react@18`'s real UMD build) has no React-19 equivalent. Bundling React removes that dependency entirely and future-proofs the widget against whatever React version the host page runs. While in there, the embed API was simplified into one object (target + options together).

## Build size (gzip vs. brotli)

| Asset | Raw | Gzip (`.gz`) | Brotli (`.br`) | Brotli vs. raw |
|---|---:|---:|---:|---:|
| `hexabot-widget.umd.js` | 646.0 KB | 184.2 KB | 143.4 KB | −78% |
| `style.css` | 32.3 KB | 5.9 KB | 5.3 KB | −84% |

Both are precompressed at build time (brotli quality 11) and served as sibling `.br`/`.gz` files — a self-hosting server serving these directly needs no runtime compression step. CDN-hosted consumers (jsDelivr/unpkg) already negotiate brotli automatically and are unaffected.

## Widget embed: before / after

**Before** (`main` — already broken independent of React 19: `token` isn't a `Config` field, `sourceId` is missing and required):

```html
<script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
<script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
<script src="./hexabot-widget.umd.js"></script>

<div id="hb-chat-widget"></div>
<script>
  // Create the shadow root and attach it to the widget container
  const createElement = (tag, props = {}) =>
    Object.assign(document.createElement(tag), props);
  const shadowContainer = createElement("div");
  document
    .getElementById("hb-chat-widget")
    .attachShadow({ mode: "open" })
    .append(
      shadowContainer,
      createElement("link", {
        rel: "stylesheet",
        href: "./style.css",
      }),
    );
  ReactDOM.render(
    React.createElement(HexabotWidget, {
      apiUrl: "http://localhost:4000",
      channel: "web",
      token: "token123", // not a Config field — silently ignored
      primaryColor: "#1ba089",
    }),
    shadowContainer,
  );
</script>
```

**After** (this branch — one script, no CDN dependency, shadow DOM and stylesheet handled internally):

```html
<script src="./hexabot-widget.umd.js"></script>

<div id="hb-chat-widget"></div>
<script>
  HexabotWidget.config({
    id: "hb-chat-widget",
    css: "./style.css",
    shadowDom: true,
    apiUrl: "http://localhost:3000",
    channel: "web",
    sourceId: "replace-with-source-id",
    language: "en",
    primaryColor: "#29998e",
  });
</script>
```

23 lines → 15. No `React`/`ReactDOM` script tags, no manual shadow-root/`<link>` wiring, no risk of a typo'd config key (like `token` above) silently doing nothing — `id`/`css`/`shadowDom` are the only options pulled out of the call, everything else flows straight into the widget's config.

## Other changes bundled in this PR

- **`primaryColor` dev/demo accent** — `#1BA089` → `#29998e` in `src/main.tsx` and `public/index.html` (cosmetic, local dev/demo only — the README's generic example color is untouched).
- **`README.md` / `AGENTS.md`** — embed snippets, directory notes, and guardrails updated to match the new `config()` API and bundling behavior; added a "Serve the Bundle" section documenting `pnpm run serve` (which was previously undocumented despite already existing).

## How to review

- **`packages/widget/vite.config.ts`** — the core fix: `external`/`globals` removed (React is bundled), `tsconfig.build.json` added because `tsconfig.app.json`'s `noEmit` was silently dropping every `.d.ts` (pre-existing bug, not caused by this change), `emptyOutDir: false` because the UMD build pass was wiping the declarations the ES pass had just written, and a `precompressAssets` plugin emitting `.br`/`.gz` for the UMD bundle and stylesheet.
- **`packages/widget/src/embed.tsx`** (new) — the public entry point. `config({ id, css, shadowDom, ...widgetProps })` resolves the target (id, CSS selector, or element), optionally creates/reuses a shadow root, injects the stylesheet into the right root, and owns the React root (re-mount-safe, returns `{ unmount }`).
- **`packages/widget/public/index.html`** — the demo/dev embed, updated to the new API and no remote script tags.
- **`packages/widget/README.md`** — embed instructions rewritten end to end.

## Validation

- `pnpm --filter @hexabot-ai/widget lint|typecheck|test|build` — all pass.
- `pnpm --filter @hexabot-ai/frontend typecheck|build` — pass (frontend deep-imports `@hexabot-ai/widget/src/UiChatWidget`, unaffected by the entry change).
- Built the real UMD bundle and mounted it in a headless DOM with **zero host React present** — confirms the widget no longer needs anything supplied by the page.
- Verified the precompressed `.br`/`.gz` files are byte-identical to what the raw bundle decompresses to (sha256 match), so the compression step can't silently corrupt what ships.
- Confirmed `dist/*.d.ts` are actually emitted post-build (previously silently empty due to the `noEmit` bug above).
