### PR TITLE
fix: resolve js-yaml v4.3.1 package vulnerability

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,7 +17,7 @@ overrides:
   hono: '>=4.12.34'
   immutable: '>=5.1.8'
   ip-address: 10.3.1
-  js-yaml: 4.3.0
+  js-yaml: 4.3.1
   jsonata: ^2.2.0
   lodash: 4.18.1
   lodash-es: 4.18.1
@@ -7191,8 +7191,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsdom@28.0.0:
@@ -11088,7 +11088,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       minimatch: 10.2.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -11307,7 +11307,7 @@ snapshots:
       camelcase: 5.3.1
       find-up: 4.1.0
       get-package-type: 0.1.0
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       resolve-from: 5.0.0
 
   '@istanbuljs/schema@0.1.3': {}
@@ -12157,7 +12157,7 @@ snapshots:
       '@nestjs/common': 11.1.19(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/core': 11.1.19(@nestjs/common@11.1.19(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.19)(@nestjs/websockets@11.1.19)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/mapped-types': 2.1.1(@nestjs/common@11.1.19(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       lodash: 4.18.1
       path-to-regexp: 8.4.2
       reflect-metadata: 0.2.2
@@ -15200,7 +15200,7 @@ snapshots:
   cosmiconfig@8.3.6(typescript@5.9.3):
     dependencies:
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
@@ -15210,7 +15210,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 5.9.3
@@ -15219,7 +15219,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 5.9.3
@@ -17437,7 +17437,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -18514,7 +18514,7 @@ snapshots:
       class-validator: 0.15.1
       cookie: 0.7.2
       iterare: 1.2.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       rxjs: 7.8.2
       string-format: 2.0.0
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -37,7 +37,7 @@ overrides:
   "hono": ">=4.12.34"
   "immutable": ">=5.1.8"
   "ip-address": "10.3.1"
-  "js-yaml": "4.3.0"
+  "js-yaml": "4.3.1"
   "jsonata": "^2.2.0"
   "lodash": "4.18.1"
   "lodash-es": "4.18.1"


### PR DESCRIPTION
## Summary
Bumps the `js-yaml` pnpm override from `4.3.0` to `4.3.1` and regenerates `pnpm-lock.yaml`, forcing all transitive dependents (eslint, jest-config, `@nestjs/*`, cosmiconfig, etc.) onto the patched version.

## Why
`js-yaml@4.3.0` is affected by [GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj). Since the repo already pins `js-yaml` via a pnpm `overrides` entry, bumping that single entry is enough to remediate every transitive usage across the workspace.

## How to review
- [pnpm-workspace.yaml](pnpm-workspace.yaml#L40): confirm the override now reads `"js-yaml": "4.3.1"`.
- [pnpm-lock.yaml](pnpm-lock.yaml): diff is mechanical — every `js-yaml@4.3.0` entry (root override, resolution block, and each package's `snapshots` dependency list) becomes `js-yaml@4.3.1`, integrity hash updated accordingly. No other packages moved.
- No application code changes.

## Validation
- `git show --stat` confirms only `pnpm-workspace.yaml` and `pnpm-lock.yaml` changed (no source files touched).
- Verified the override is correctly picked up by all transitive consumers of `js-yaml` in the regenerated lockfile (eslint, jest-config, `@nestjs/common`, `@nestjs/config`, cosmiconfig, etc. all now resolve to `4.3.1`).
