### PR TITLE
fix(api): restore assignment-style class field emit

### DIFF
--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "module": "commonjs",
     "declaration": true,
+    "useDefineForClassFields": false,
     "removeComments": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,


### PR DESCRIPTION
## Summary

Set `useDefineForClassFields: false` in `packages/api/tsconfig.json`. The 3.4.2 build emitted declared entity properties as native ECMAScript class fields, which breaks TypeORM persistence: `updateOne()` overwrites the loaded entity's primary key with `undefined` and silently issues an `INSERT` instead of an `UPDATE`. This restores the emit shipped by 3.4.0 and earlier.

## Why

`packages/api/tsconfig.json` sets `target: "ES2022"` with no explicit `useDefineForClassFields`. TypeScript defaults that flag to `true` at ES2022+, so every declared-but-uninitialized entity property became a real class field in 3.4.2's `dist`:

| `dist/database/entities/base.entity.js` | native class fields |
|---|---|
| 3.3.4 | 0 |
| 3.4.0 | 0 |
| **3.4.2** | **3** (`id`, `createdAt`, `updatedAt`) |

`src/` is byte-identical across all three releases — including `base-orm.repository.ts`. Only the compiled output changed, so this is purely a build regression.

The failure chain:

1. Native class fields make `new Entity()` define `id` as an **own property equal to `undefined`**.
2. `actionDtoToEntity()` builds its update object via `plainToInstance()`, so the result now carries `id: undefined` that the payload never contained.
3. `updateOne()` does `Object.assign(entity, updates)`, overwriting the loaded entity's real primary key.
4. With no id, TypeORM's `Subject.identifier` is `undefined` → `SubjectDatabaseEntityLoader` skips it → `mustBeInserted` → `save()` emits an `INSERT`.

This affects **every entity in the package**, not one feature. The most visible symptom is that the admin console/chat-preview becomes unusable on the community tier — `LicenseOrmListener.beforeInsert` is simply the first insert-guard the spurious `INSERT` trips:

```
ForbiddenException: Cannot create user: community plan allows up to 1 user.
    at LicenseOrmListener.beforeInsert (license/services/license-orm-listener.service.ts:116)
    at SubjectExecutor.execute → EntityPersistExecutor.execute
    at SubscriberRepository.updateOne (utils/generics/base-orm.repository.ts:363)
```

Elsewhere the same defect can null columns, create duplicate rows, or fail unique constraints.

The bug did not surface in local development because dev runs SWC (`.swcrc`: `target: es2021`, `loose: true`), which emits assignment-style fields. Only the `tsc`-built published package is affected — which is why it reproduces solely for consumers of the npm package.

## How to review

One file, one line: `packages/api/tsconfig.json`.

The line restores the exact emit that 3.3.4 and 3.4.0 shipped, so this is a return to a known-good state rather than new behaviour. It applies to all classes in the package, not just entities — which is precisely what the pre-3.4.2 builds did.

Scope note: this is deliberately the minimal hotfix so it can land for a 3.4.3 quickly, since 3.4.2 is broken for every npm consumer. The underlying fragility is `actionDtoToEntity()` merging a constructed entity's own properties onto a loaded one via `Object.assign()` — that code is unchanged since 3.3.4 and is not the regression, but it is what made the compiler change fatal. Hardening it is worth a follow-up so this class of bug can't recur.

Alternatives considered and rejected:

- **SWC builder** — would drop all 560 `.d.ts` files (`types: dist/index.d.ts`), breaking every TypeScript consumer. Viable only with a separate `tsc --emitDeclarationOnly` step.
- **`declare` on entity fields** — works (`@PrimaryColumn() declare id: string`; note `declare id!: string` is a compile error, TS1255), but it's a per-property opt-out for a package-wide problem and silently regresses the first time a field is added without it.
- **`target: ES2021`** — equivalent effect, but drags unrelated emit changes along.
- **`exposeUnsetFields: false`** — verified ineffective; class fields are installed by the constructor before class-transformer assigns anything.

## Validation

- Compared published tarballs 3.3.4 / 3.4.0 / 3.4.2: `src/` identical for all files in the failure path; only `dist/` differs.
- Reproduced the semantics directly against the repo's own `class-transformer`: old emit → `Object.assign` preserves `id` (UPDATE); new emit → `id` becomes `undefined` (INSERT).
- Confirmed the emit change with `tsc` at `target: ES2022` with and without the flag.
- Verified declaration output is unaffected: `find packages/api/dist -name "*.d.ts" | wc -l` → 560, unchanged.
- Post-build check on this branch:
  ```bash
  grep -rE "^\s+[A-Za-z_$][A-Za-z0-9_$]*;\s*$" packages/api/dist --include="*.entity.js" | wc -l   # 0
  ```
- End-to-end against a starter template consuming the packed build, fresh DB: logged in as the seeded admin and opened the dashboard chat preview. No `ForbiddenException`; the subscriber row is updated in place rather than re-inserted:
  ```
  sqlite3 hexabot.sqlite "SELECT id, type, channelName, source_id, created_at, updated_at FROM users;"
  # 1 row, type=UserOrmEntity, channelName=console, source_id set, updated_at > created_at
  ```
- Regression check: `pnpm --filter @hexabot-ai/api test`.