### PR TITLE
fix(cli): correct negated option handling

### DIFF
--- a/packages/cli/src/commands/check.ts
+++ b/packages/cli/src/commands/check.ts
@@ -19,7 +19,6 @@ import { isHexabotProject } from '../core/project.js';
 interface CheckCommandOptions {
   dockerOnly?: boolean;
   docker?: boolean;
-  noDocker?: boolean;
 }
 
 export const registerCheckCommand = (program: Command) => {
@@ -28,21 +27,13 @@ export const registerCheckCommand = (program: Command) => {
     .description('Run diagnostic checks')
     .option('--docker-only', 'Only run Docker checks')
     .option('--no-docker', 'Skip Docker checks')
-    .action((options: CheckCommandOptions) => {
-      runDiagnostics({
-        dockerOnly: options.dockerOnly,
-        noDocker: options.noDocker ?? options.docker === false,
-      });
-    });
+    .action(runDiagnostics);
 };
 
-const runDiagnostics = (options: {
-  dockerOnly?: boolean;
-  noDocker?: boolean;
-}) => {
+const runDiagnostics = (options: CheckCommandOptions) => {
   const projectRoot = process.cwd();
   const onlyDocker = options.dockerOnly;
-  const skipDocker = options.noDocker;
+  const skipDocker = !options.docker;
   const results: DiagnosticResult[] = [];
 
   if (!onlyDocker) {

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -28,7 +28,7 @@ const DEFAULT_TEMPLATE_REPO = 'hexastack/hexabot-template-starter';
 interface CreateCommandOptions {
   template?: string;
   pm?: string;
-  noInstall?: boolean;
+  install?: boolean;
   dev?: boolean;
   docker?: boolean;
   force?: boolean;
@@ -57,9 +57,7 @@ export const registerCreateCommand = (program: Command) => {
       'Show Docker/Postgres next steps and use Docker mode with --dev',
     )
     .option('--force', 'Allow scaffolding into a non-empty directory')
-    .action(async (projectName: string, options: CreateCommandOptions) => {
-      await createProject(projectName, options);
-    });
+    .action(createProject);
 };
 
 const createProject = async (
@@ -105,7 +103,7 @@ const createProject = async (
       projectName,
     );
 
-    if (options.noInstall) {
+    if (!options.install) {
       console.log(
         chalk.yellow('Skipping dependency installation (--no-install).'),
       );
@@ -119,7 +117,7 @@ const createProject = async (
     logSuccessMessage(projectName, { docker: options.docker });
 
     if (options.dev) {
-      if (options.noInstall) {
+      if (!options.install) {
         console.log(
           chalk.yellow(
             'Dependencies were not installed. Run `npm install` before `--dev`.',


### PR DESCRIPTION
## Summary

`hexabot create --no-install` was silently ignored: the code branched on `options.noInstall`, but Commander maps `--no-x` to the key `x` (defaulted to `true`, set to `false` when the flag is passed) and never emits a `noX` key. Both branches in `create.ts` now read `!options.install`, and `check.ts` drops the same dead `noDocker` field, which had been masked by a `??` fallback.

## Why

`--no-install` was a no-op — dependencies installed regardless of the flag, and the `"Dependencies were not installed. Run npm install before --dev."` guard could never fire.

Nothing caught it. `tsc` was satisfied because the phantom field was declared on the hand-written options interface, and no test exercised the flag. `check.ts` carried the identical mistake but happened to behave correctly, because `options.noDocker ?? options.docker === false` fell through to the working operand.

## How to review

- **`create.ts`** — the behavioural change. Both call sites must be negated; fixing only the first leaves `--dev` inverted, so it warns instead of starting the dev server and starts the dev server when dependencies are missing.
- **`check.ts`** — no behavioural change, cleanup only. `skipDocker = !options.docker` replaces the `??` chain now that `noDocker` is gone.
- **`.action(createProject)` / `.action(runDiagnostics)`** — the wrapper arrows were dropped. Worth a look: Commander invokes the action with `(...args, options, command)`, so `createProject` still receives `(projectName, options)` and the trailing `command` argument is ignored.
- Reference for the mapping, if you want to confirm it independently: `commander/lib/option.js` `attributeName()` strips the `no-` prefix, and `lib/command.js` `addOption()` seeds the default `true` for negated flags.

## Validation

| Check | Result |
| --- | --- |
| `npx tsc --noEmit` | pass |
| `npx eslint "src/**/*.ts"` | clean |
| existing Jest suite | 53/53 pass |

Behaviour verified directly (ad-hoc, not committed):

**`create`**

| Invocation | Installs? | Starts dev? |
| --- | --- | --- |
| _no flags_ | yes | no |
| `--no-install` | no | no |
| `--dev` | yes | yes |
| `--dev --no-install` | no | no, warns |

Project name and `--template` confirmed still forwarded through the bare `.action()`.

**`check`** — run via `tsx src/index.ts`, Docker checks execute 2 / 0 / 2 for no flags / `--no-docker` / `--docker-only`, matching pre-change behaviour.

### Known gap

No regression test is included. The suite passes identically with and without this fix, so it cannot detect a reoccurrence. The four `create` cases in the table above are the coverage that would close it.