### PR TITLE
fix(api): stop OR branches sharing nested where clauses

### DIFF
--- a/packages/api/src/utils/pipes/typeorm-search-filter.pipe.spec.ts
+++ b/packages/api/src/utils/pipes/typeorm-search-filter.pipe.spec.ts
@@ -13,6 +13,7 @@ type TestEntity = {
   name: string;
   email: string;
   createdAt: Date;
+  owner: { id: string; country: string };
 };
 
 describe('TypeOrmSearchFilterPipe', () => {
@@ -93,6 +94,31 @@ describe('TypeOrmSearchFilterPipe', () => {
     );
 
     expect(defaultSort.order).toEqual({ createdAt: 'DESC' });
+  });
+
+  // Each OR branch must inherit the AND filter (owner.id) while overriding it
+  // where they overlap (owner.country), without leaking into its siblings.
+  it('should keep every OR branch independent when nested with an AND filter', async () => {
+    const nestedPipe = new TypeOrmSearchFilterPipe<TestEntity>({
+      allowedFields: ['owner.id', 'owner.country'],
+    });
+    const result = await nestedPipe.transform(
+      {
+        where: {
+          'owner.id': 'OWNER-1',
+          or: [
+            { 'owner.country': 'United Kingdom' },
+            { 'owner.country': 'United States' },
+          ],
+        },
+      } as any,
+      {} as any,
+    );
+
+    expect(result.where).toEqual([
+      { owner: { id: 'OWNER-1', country: 'United Kingdom' } },
+      { owner: { id: 'OWNER-1', country: 'United States' } },
+    ]);
   });
 
   describe('prototype pollution prevention', () => {

--- a/packages/api/src/utils/pipes/typeorm-search-filter.pipe.ts
+++ b/packages/api/src/utils/pipes/typeorm-search-filter.pipe.ts
@@ -143,7 +143,7 @@ export class TypeOrmSearchFilterPipe<T>
       return undefined;
     }
 
-    const baseWhere: FindOptionsWhere<T> = {} as FindOptionsWhere<T>;
+    let baseWhere: FindOptionsWhere<T> = {} as FindOptionsWhere<T>;
     const orClauses: FindOptionsWhere<T>[] = [];
 
     for (const filter of filters) {
@@ -153,7 +153,7 @@ export class TypeOrmSearchFilterPipe<T>
       if (filter.context === 'or') {
         orClauses.push(clause);
       } else {
-        this.mergeWhereObjects(baseWhere, clause);
+        baseWhere = this.mergeWhereObjects(baseWhere, clause);
       }
     }
 
@@ -167,12 +167,7 @@ export class TypeOrmSearchFilterPipe<T>
       return orClauses;
     }
 
-    return orClauses.map((clause) =>
-      this.mergeWhereObjects(
-        { ...(baseWhere as Record<string, unknown>) } as FindOptionsWhere<T>,
-        clause,
-      ),
-    );
+    return orClauses.map((clause) => this.mergeWhereObjects(baseWhere, clause));
   }
 
   private parseNumber(
@@ -412,28 +407,31 @@ export class TypeOrmSearchFilterPipe<T>
     cursor[segments[segments.length - 1]] = value;
   }
 
+  // Must stay pure: the same base clause is merged into every `or` branch.
   private mergeWhereObjects(
     left: FindOptionsWhere<T>,
     right: FindOptionsWhere<T>,
   ): FindOptionsWhere<T> {
+    const merged = {
+      ...left,
+    };
+
     for (const [key, value] of Object.entries(right)) {
       if (value === undefined || hasForbiddenSegment(key)) {
         continue;
       }
 
-      const existing = (left as Record<string, unknown>)[key];
-      if (this.isPlainObject(existing) && this.isPlainObject(value)) {
-        this.mergeWhereObjects(
-          existing as FindOptionsWhere<T>,
-          value as FindOptionsWhere<T>,
-        );
-        continue;
-      }
-
-      (left as Record<string, unknown>)[key] = value;
+      const existing = merged[key];
+      merged[key] =
+        this.isPlainObject(existing) && this.isPlainObject(value)
+          ? this.mergeWhereObjects(
+              existing as FindOptionsWhere<T>,
+              value as FindOptionsWhere<T>,
+            )
+          : value;
     }
 
-    return left;
+    return merged as FindOptionsWhere<T>;
   }
 
   private hasWhereEntries(where: FindOptionsWhere<T>): boolean {


### PR DESCRIPTION
## Summary

`TypeOrmSearchFilterPipe` merged the shared AND clause into every `OR` branch by **mutating** it, so all branches ended up referencing one nested object and collapsed into the last branch's values. `mergeWhereObjects` is now pure — it constructs a new object instead of writing into its `left` argument — which keeps each branch independent. Scoped deliberately to this one defect.

## Reproduce — Inbox search

1. Assign a conversation to yourself.
2. Set **Assigned To** to `Assigned to me` and leave the search empty — the conversation is listed.
3. Search the subscriber's **last name** — the list goes empty. **← the bug**
4. Set **Assigned To** back to `All Messages`, keeping the search text — the conversation reappears.

## Why

Any request that combines an AND filter with an `OR` group on the **same nested relation** silently returned the wrong rows. For `owner.id = OWNER-1 AND (owner.country = United Kingdom OR owner.country = United States)`:

```sql
-- produced
WHERE (owner.id='OWNER-1' AND owner.country='United States')
   OR (owner.id='OWNER-1' AND owner.country='United States')   -- collapses to one branch

-- expected
WHERE (owner.id='OWNER-1' AND owner.country='United Kingdom')
   OR (owner.id='OWNER-1' AND owner.country='United States')
```

The last branch always won, so an N-way `OR` degenerated into N copies of it — the more options a user selected, the more results disappeared. There was no error and no warning: HTTP 200 with a plausible-looking, incomplete result set.

This is reachable in production today, not theoretical: nested filter fields are registered on `GET /credential` (`owner.id`) and `GET /source` (`defaultWorkflow.id`). The same root cause also produced wrong results when the AND filter and the branches set the *same* nested leaf; that case is fixed here too.

Flat, non-nested filters were never affected, which is why the existing OR test stayed green.

## How to review

Start at `mergeWhereObjects` in `packages/api/src/utils/pipes/typeorm-search-filter.pipe.ts` — mutation → construction is the whole behavioural change. Everything else follows from it:

| Change | Why it's required |
|---|---|
| `const baseWhere` → `let` + reassign | With a pure merge, discarding the return value would leave `baseWhere` empty and drop **every** AND filter. |
| `{ ...baseWhere }` spread deleted at the `.map` | It was an ineffective guard — shallow, so nested objects stayed shared. The merge copies now. |

Two things worth confirming explicitly:

- **Precedence is unchanged** — branch values still override base values on conflict. This is the property most easily inverted by accident.
- **No `structuredClone`.** Deep-cloning the base per branch looks like the obvious fix but throws here: nested `contains` filters put `FindOperator` (`ILike`) instances at the leaves. Making the merge non-mutating avoids the problem rather than defending against it — sharing a reference is harmless once nothing writes through it.

## Validation

| Check | Result |
|---|---|
| `typeorm-search-filter.pipe.spec.ts` | 15/15 passing |
| Full API suite | 1231 passed, 3 skipped, 0 failed (177 suites) |
| `typecheck` / `eslint` / `prettier` | clean |

The regression test was verified to **fail** against the pre-fix implementation, reproducing the reported symptom: both branches came back as `United States`, silently dropping the `United Kingdom` results.

`allowedFields` in the spec also dropped its `as any`, so `TFilterNestedKeysOfType` now validates nested filter paths at compile time — a stale or misspelled key becomes a build error instead of a silently-skipped filter.
