### PR TITLE
fix(widget): remove duplicated files from dist folder

### DIFF
--- a/packages/widget/package.json
+++ b/packages/widget/package.json
@@ -22,8 +22,7 @@
     "./package.json": "./package.json"
   },
   "files": [
-    "dist",
-    "README.md"
+    "dist"
   ],
   "scripts": {
     "dev": "vite",

--- a/packages/widget/vite.config.ts
+++ b/packages/widget/vite.config.ts
@@ -23,22 +23,6 @@ const emitCommonJsAlias = (outDir: string): Plugin => ({
     );
   },
 });
-/** Copies release metadata that must travel with every built widget artifact. */
-const copyBuildMetadata = (outDir: string): Plugin => ({
-  name: "hexabot-build-metadata",
-  apply: "build",
-  closeBundle() {
-    copyFileSync(
-      resolve(__dirname, "../../LICENSE.md"),
-      resolve(outDir, "LICENSE.md"),
-    );
-    copyFileSync(resolve(__dirname, "README.md"), resolve(outDir, "README.md"));
-    copyFileSync(
-      resolve(__dirname, "package.json"),
-      resolve(outDir, "package.json"),
-    );
-  },
-});
 /** Makes the browser global both callable and usable as an export namespace. */
 const exposeLegacyUmdDefault = (): Plugin => ({
   name: "hexabot-legacy-umd-default",
@@ -77,7 +61,6 @@ export default defineConfig(({ mode }) => {
         bundleTypes: true,
       }),
       exposeLegacyUmdDefault(),
-      copyBuildMetadata(resolve(__dirname, "dist")),
       emitCommonJsAlias(resolve(__dirname, "dist")),
     ],
     oxc: {


### PR DESCRIPTION
## Summary

Simplified the widget package output by removing duplicated metadata files from `dist` and limiting published files to the `dist` directory. Updated the UMD demo to load the published `3.5.0-beta.1` assets from jsDelivr.

## Why

NPM already includes the root `package.json`, README, and license metadata, so copying them into `dist` created unnecessary duplicates in the published CDN structure.

## How to review

Focus on:

- The `files` allowlist in `packages/widget/package.json`.
- Removal of the metadata-copy plugin from `vite.config.ts`.
- The pinned CDN URLs and configured source ID in `public/index.html`.
- Preservation of ESM, UMD, and CommonJS outputs.

## Validation

- Ran widget lint successfully.
- Ran the production build successfully.
- Used `pnpm pack --dry-run` to verify the final package structure.
- Confirmed duplicated metadata files are absent from `dist`.