### PR TITLE
feat(api): new middleware helper kind

### DIFF
--- a/packages/api/AGENTS.md
+++ b/packages/api/AGENTS.md
@@ -56,6 +56,7 @@ Use this file as the entrypoint for AI coding agents working on the Hexabot API.
 - Extension cleanup runs on application bootstrap in `packages/api/src/extension/extension.module.ts`.
 - Use extension settings instead of hardcoded behavior when adding new channel/action/helper behavior.
 - Channel/helper runtime setting group keys and settings hook namespaces must match the extension `name` (kebab-case).
+- Inbound **middleware** helpers (`BaseMiddlewareHelper`, helper type `middleware`) form an onion chain that wraps all post-decode inbound processing via `ChannelHandler.dispatchInboundEvent(event, next)`; every registered one runs, ordered by `getPriority()`. Keep them self-contained (`ChannelInboundEvent` accessors only). See `src/helper/README.md`.
 
 ## Coding conventions and gotchas
 - All new TS files must include the license header; ESLint `header/header` enforces it.

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -25,7 +25,7 @@ The API is divided into several key modules, each responsible for specific funct
 - **CMS:** Content types, content entries, and menus.
 - **Workflow:** Workflow definitions, runs, scheduling, memory definitions, and agentic execution.
 - **Actions:** Registry for action extensions used by workflows.
-- **Helper:** Registry for helper extensions such as storage and utility helpers.
+- **Helper:** Registry for helper extensions such as storage, RAG, utility, and inbound-middleware helpers.
 - **I18n:** Languages, translations, and runtime localization.
 - **User:** Authentication, roles, permissions, invitations, and password reset.
 - **Settings:** Settings and metadata management.

--- a/packages/api/src/channel/README.md
+++ b/packages/api/src/channel/README.md
@@ -27,7 +27,9 @@ At request time:
 2. `ChannelService` resolves an active `Source` by `sourceRef`, then resolves the handler by `source.channel`.
 3. The handler transport (`HttpChannelHandler` or `WebSocketChannelHandler`) processes the request.
 4. Inbound payloads are decoded into `ChannelInboundEvent` instances.
-5. Events are emitted through `ChannelEventBus` to the chatbot/workflow pipeline.
+5. Each event's post-decode processing is wrapped by the inbound middleware
+   chain via `ChannelHandler.dispatchInboundEvent(event, next)` (see below).
+6. Events are emitted through `ChannelEventBus` to the chatbot/workflow pipeline.
 
 ## HTTP Surface
 
@@ -81,6 +83,19 @@ Optional extension points:
 - `getSubscriberAvatar(event)`
 - `hasDownloadAccess(attachment, req)`
 - `getAttachmentPublicUrl(sourceId, attachment)`
+
+### Inbound middleware boundary (`dispatchInboundEvent`)
+
+`dispatchInboundEvent(event, next)` runs a decoded event through the inbound
+middleware chain (see `src/helper/README.md`), wrapping **all post-decode
+processing** as `next` — subscriber resolution, uploads, thread resolution,
+broadcasts, and hook emission. A middleware may inspect, mutate, or **drop** the
+event (short-circuiting the whole block).
+
+Both built-in transports already route every event through it. A custom handler
+that overrides `handle()` or dispatches events itself (e.g. a gateway channel)
+**must** call `dispatchInboundEvent(event, () => …)` for its events to be seen
+by middleware.
 
 ### Transport Base Classes
 

--- a/packages/api/src/channel/lib/Handler.ts
+++ b/packages/api/src/channel/lib/Handler.ts
@@ -30,6 +30,7 @@ import {
 } from '@/attachment/types';
 import { MessageInboundEvent } from '@/channel/lib/inbound-events';
 import { SubscriberCreateDto } from '@/chat/dto/subscriber.dto';
+import { InboundMiddlewareService } from '@/helper/inbound-middleware.service';
 import { Extension } from '@/utils/generics/extension';
 import { SocketRequest } from '@/websocket/utils/socket-request';
 import { SocketResponse } from '@/websocket/utils/socket-response';
@@ -44,6 +45,7 @@ import {
 } from './channel-capabilities';
 import { ChannelEventBus } from './channel-event-bus';
 import { collectExtensionInjectMeta } from './extension-inject.decorator';
+import type ChannelInboundEvent from './inbound-events/channel-inbound-event';
 import { UnsupportedOutgoingFormatError } from './outbound';
 
 @Injectable()
@@ -64,6 +66,9 @@ export default abstract class ChannelHandler<
 
   @Inject(ChannelEventBus)
   protected readonly channelEventBus: ChannelEventBus;
+
+  @Inject(InboundMiddlewareService)
+  private readonly inboundMiddlewareService: InboundMiddlewareService;
 
   @Inject(ModuleRef)
   private readonly moduleRef: ModuleRef;
@@ -99,6 +104,23 @@ export default abstract class ChannelHandler<
 
   protected async createModuleRef<T>(provider: Type<T>): Promise<T> {
     return await this.moduleRef.create(provider);
+  }
+
+  /**
+   * Runs a decoded inbound event through the inbound middleware chain, wrapping
+   * all post-decode processing as `next` (subscriber resolution, attachment
+   * persistence/uploads, thread resolution, broadcasts, hook emission).
+   *
+   * Every transport MUST route inbound events through this boundary before
+   * performing that processing, so middleware applies uniformly across channels.
+   * A middleware that drops the event (never calls `next`) short-circuits the
+   * entire block — none of the above side effects run.
+   */
+  protected async dispatchInboundEvent(
+    event: ChannelInboundEvent,
+    next: () => Promise<void>,
+  ): Promise<void> {
+    await this.inboundMiddlewareService.run(event, next);
   }
 
   /**

--- a/packages/api/src/channel/lib/transports/http-channel-handler.spec.ts
+++ b/packages/api/src/channel/lib/transports/http-channel-handler.spec.ts
@@ -1,0 +1,163 @@
+/*
+ * Hexabot — Fair Core License (FCL-1.0-ALv2)
+ * Copyright (c) 2026 Hexastack.
+ * Full terms: see LICENSE.md.
+ */
+
+import { Source, StdEventType } from '@hexabot-ai/types';
+import { Request, Response } from 'express';
+
+import { HelperService } from '@/helper/helper.service';
+import { InboundMiddlewareService } from '@/helper/inbound-middleware.service';
+import {
+  BaseMiddlewareHelper,
+  InboundMiddlewareNext,
+} from '@/helper/lib/base-middleware-helper';
+import { HelperType } from '@/helper/types';
+
+import type ChannelInboundEvent from '../inbound-events/channel-inbound-event';
+
+import { HttpChannelHandler } from './http-channel-handler';
+
+class TestHttpChannelHandler extends HttpChannelHandler<any> {
+  public decoded: ChannelInboundEvent<any>[] = [];
+
+  protected async decode(): Promise<ChannelInboundEvent<any>[]> {
+    return this.decoded;
+  }
+
+  protected async doSendMessage(): Promise<any> {
+    return undefined;
+  }
+
+  async getSubscriberData(): Promise<any> {
+    return {};
+  }
+}
+
+/** Minimal middleware double driven by the provided `handle` callback. */
+const makeMiddleware = (
+  priority: number,
+  handle: (
+    event: ChannelInboundEvent,
+    next: InboundMiddlewareNext,
+  ) => Promise<void>,
+): BaseMiddlewareHelper =>
+  ({
+    getName: () => `mw-${priority}`,
+    getType: () => HelperType.MIDDLEWARE,
+    getPriority: () => priority,
+    handle,
+  }) as unknown as BaseMiddlewareHelper;
+
+describe('HttpChannelHandler inbound middleware ordering', () => {
+  const source = { id: 'src-1', settings: {} } as unknown as Source;
+
+  let handler: TestHttpChannelHandler;
+  let helperService: jest.Mocked<Pick<HelperService, 'getAllByType'>>;
+  let emitMessage: jest.Mock;
+  let emitStatusEvent: jest.Mock;
+  let resolveSubscriber: jest.SpyInstance;
+  let order: string[];
+
+  const buildEvent = (type: StdEventType) => {
+    const preprocess = jest.fn(async () => {
+      order.push('preprocess');
+    });
+
+    return {
+      setHandler: jest.fn(),
+      setSourceContext: jest.fn(),
+      setWorkflowId: jest.fn(),
+      setInitiator: jest.fn(() => order.push('setInitiator')),
+      getEventType: () => type,
+      preprocess,
+    } as unknown as ChannelInboundEvent<any>;
+  };
+  const res = {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+  } as unknown as Response;
+  const req = { method: 'POST', body: {} } as unknown as Request;
+
+  beforeEach(() => {
+    order = [];
+    helperService = { getAllByType: jest.fn().mockReturnValue([]) };
+    handler = new TestHttpChannelHandler('test' as any);
+    (handler as any).logger = {
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+    };
+    (handler as any).inboundMiddlewareService = new InboundMiddlewareService(
+      helperService as unknown as HelperService,
+    );
+    emitMessage = jest.fn(async () => {
+      order.push('emitMessage');
+    });
+    emitStatusEvent = jest.fn(() => {
+      order.push('emitStatusEvent');
+    });
+    (handler as any).channelEventBus = { emitMessage, emitStatusEvent };
+    resolveSubscriber = jest
+      .spyOn(handler as any, 'resolveSubscriber')
+      .mockImplementation(async () => {
+        order.push('resolveSubscriber');
+
+        return { id: 'sub-1' };
+      });
+  });
+
+  it('short-circuits before subscriber resolution, preprocessing and dispatch when dropped', async () => {
+    handler.decoded = [buildEvent(StdEventType.message)];
+    helperService.getAllByType.mockReturnValue([
+      makeMiddleware(0, async () => {
+        // drop: never calls next()
+        order.push('mw:drop');
+      }),
+    ] as any);
+
+    await handler.handle(req, res, source);
+
+    expect(order).toEqual(['mw:drop']);
+    expect(resolveSubscriber).not.toHaveBeenCalled();
+    expect(emitMessage).not.toHaveBeenCalled();
+    expect(emitStatusEvent).not.toHaveBeenCalled();
+  });
+
+  it('runs the full message pipeline inside the onion when proceeding', async () => {
+    handler.decoded = [buildEvent(StdEventType.message)];
+    helperService.getAllByType.mockReturnValue([
+      makeMiddleware(0, async (_e, next) => {
+        order.push('mw:before');
+        await next();
+        order.push('mw:after');
+      }),
+    ] as any);
+
+    await handler.handle(req, res, source);
+
+    expect(order).toEqual([
+      'mw:before',
+      'resolveSubscriber',
+      'setInitiator',
+      'preprocess',
+      'emitMessage',
+      'mw:after',
+    ]);
+  });
+
+  it('short-circuits status events too when dropped', async () => {
+    handler.decoded = [buildEvent(StdEventType.delivery)];
+    helperService.getAllByType.mockReturnValue([
+      makeMiddleware(0, async () => {
+        // drop
+      }),
+    ] as any);
+
+    await handler.handle(req, res, source);
+
+    expect(resolveSubscriber).not.toHaveBeenCalled();
+    expect(emitStatusEvent).not.toHaveBeenCalled();
+  });
+});

--- a/packages/api/src/channel/lib/transports/http-channel-handler.ts
+++ b/packages/api/src/channel/lib/transports/http-channel-handler.ts
@@ -115,16 +115,21 @@ export abstract class HttpChannelHandler<N extends ChannelName>
       }
 
       try {
-        const subscriber = await this.resolveSubscriber(event);
-        event.setInitiator(subscriber);
+        // Wrap all post-decode processing in the inbound middleware chain, so a
+        // dropped event (e.g. a provider redelivery) resolves no subscriber,
+        // persists nothing, and is never dispatched.
+        await this.dispatchInboundEvent(event, async () => {
+          const subscriber = await this.resolveSubscriber(event);
+          event.setInitiator(subscriber);
 
-        if (event.getEventType() === StdEventType.message) {
-          const messageEvent = event as unknown as MessageInboundEvent<N>;
-          await messageEvent.preprocess();
-          await this.channelEventBus.emitMessage(messageEvent);
-        } else {
-          this.channelEventBus.emitStatusEvent(event);
-        }
+          if (event.getEventType() === StdEventType.message) {
+            const messageEvent = event as unknown as MessageInboundEvent<N>;
+            await messageEvent.preprocess();
+            await this.channelEventBus.emitMessage(messageEvent);
+          } else {
+            this.channelEventBus.emitStatusEvent(event);
+          }
+        });
       } catch (err) {
         this.logger.error('Failed to process webhook event', err);
       }

--- a/packages/api/src/extensions/channels/web/__test__/index.spec.ts
+++ b/packages/api/src/extensions/channels/web/__test__/index.spec.ts
@@ -21,6 +21,7 @@ import { MessageService } from '@/chat/services/message.service';
 import { SubscriberService } from '@/chat/services/subscriber.service';
 import { ThreadService } from '@/chat/services/thread.service';
 import { MenuService } from '@/cms/services/menu.service';
+import { InboundMiddlewareService } from '@/helper/inbound-middleware.service';
 import { installLabelGroupFixturesTypeOrm } from '@/utils/test/fixtures/label-group';
 import { installMessageFixturesTypeOrm } from '@/utils/test/fixtures/message';
 import { I18nServiceProvider } from '@/utils/test/providers/i18n-service.provider';
@@ -71,6 +72,12 @@ describe('WebChannelHandler', () => {
   } as jest.Mocked<
     Pick<SourceService, 'findActiveById' | 'ensureDefaultSources'>
   >;
+  const inboundMiddlewareServiceMock = {
+    // Default: pass-through onion — always run the downstream `next`.
+    run: jest.fn().mockImplementation(async (_event, next) => {
+      await next();
+    }),
+  } as jest.Mocked<Pick<InboundMiddlewareService, 'run'>>;
 
   beforeAll(async () => {
     webSource = {
@@ -117,6 +124,10 @@ describe('WebChannelHandler', () => {
         {
           provide: SourceService,
           useValue: sourceServiceMock,
+        },
+        {
+          provide: InboundMiddlewareService,
+          useValue: inboundMiddlewareServiceMock,
         },
       ],
       typeorm: {
@@ -1095,6 +1106,74 @@ describe('WebChannelHandler', () => {
       }),
     );
     clearMock.mockRestore();
+  });
+
+  it('short-circuits uploads, thread resolution, broadcast and dispatch when middleware drops', async () => {
+    attachmentServiceMock.store.mockClear();
+    websocketGatewayMock.broadcast.mockClear();
+    // Middleware drops by not invoking the downstream `next`.
+    inboundMiddlewareServiceMock.run.mockImplementationOnce(async () => {
+      // intentionally skip next()
+    });
+
+    const req = {
+      isSocket: true,
+      query: { first_name: 'Drop', last_name: 'Upload' },
+      session: {},
+      headers: { 'user-agent': 'browser' },
+      socket: { handshake: { address: '127.0.0.1' } },
+      user: {},
+    } as any as SocketRequest;
+    const profile = await handler['getOrCreateSession'](req as any, webSource);
+    const fileBuffer = Buffer.from('dropped');
+    req.body = {
+      type: 'file',
+      data: {
+        type: 'image/png',
+        size: fileBuffer.byteLength,
+        name: 'dropped.png',
+        file: fileBuffer,
+      },
+    };
+    req.query = {};
+    req.session.web = { ...req.session.web, profile };
+
+    const emitMessageSpy = jest
+      .spyOn(handler['channelEventBus'], 'emitMessage')
+      .mockResolvedValue(undefined);
+    const resolveThreadSpy = jest.spyOn(
+      handler['sessionService'] as any,
+      'resolveThreadForIncoming',
+    );
+
+    await new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(
+        () => reject(new Error('Timed out waiting for response')),
+        2000,
+      );
+      const res = {
+        status: (code: number) => {
+          expect(code).toEqual(200);
+
+          return res;
+        },
+        json: () => {
+          clearTimeout(timeout);
+          resolve();
+        },
+      } as any as SocketResponse;
+
+      handler['handleEvent'](req as any, res, webSource);
+    });
+
+    await Promise.resolve();
+    expect(inboundMiddlewareServiceMock.run).toHaveBeenCalled();
+    expect(attachmentServiceMock.store).not.toHaveBeenCalled();
+    expect(resolveThreadSpy).not.toHaveBeenCalled();
+    expect(websocketGatewayMock.broadcast).not.toHaveBeenCalled();
+    expect(emitMessageSpy).not.toHaveBeenCalled();
+    emitMessageSpy.mockRestore();
+    resolveThreadSpy.mockRestore();
   });
 
   it('rejects file metadata events when binary payload is missing', async () => {

--- a/packages/api/src/extensions/channels/web/base-web-channel.ts
+++ b/packages/api/src/extensions/channels/web/base-web-channel.ts
@@ -519,94 +519,110 @@ export default abstract class BaseWebChannelHandler<N extends ChannelName>
       event.setInitiator(profile);
       event.setWorkflowId(workflowId);
 
-      if (event.getEventType() === StdEventType.message) {
-        const messageEvent = event as WebMessageInboundEvent<
-          N,
-          Web.InboundMessage
-        >;
+      // Wrap all post-decode processing (uploads, thread resolution,
+      // broadcasts, dispatch) in the inbound middleware chain. A dropped event
+      // short-circuits the block; `abort` is set only when the callback itself
+      // sends an error response.
+      let abort = false;
+      await this.dispatchInboundEvent(event, async () => {
+        if (event.getEventType() === StdEventType.message) {
+          const messageEvent = event as WebMessageInboundEvent<
+            N,
+            Web.InboundMessage
+          >;
 
-        if (messageEvent instanceof AttachmentMessageInboundEvent) {
-          try {
-            const attachment = await this.handleWsUpload(req);
-            if (attachment) {
-              messageEvent.setUploadedAttachment(attachment);
-              messageEvent.setUploadedRawData(
-                AttachmentOrmEntity.getTypeByMime(attachment.type),
-                await this.channelAttachmentService.getPublicUrl(
-                  source.id,
-                  attachment,
-                ),
-              );
+          if (messageEvent instanceof AttachmentMessageInboundEvent) {
+            try {
+              const attachment = await this.handleWsUpload(req);
+              if (attachment) {
+                messageEvent.setUploadedAttachment(attachment);
+                messageEvent.setUploadedRawData(
+                  AttachmentOrmEntity.getTypeByMime(attachment.type),
+                  await this.channelAttachmentService.getPublicUrl(
+                    source.id,
+                    attachment,
+                  ),
+                );
+              }
+            } catch (err) {
+              this.logger.warn('Unable to upload file ', err);
+              res
+                .status(403)
+                .json({ err: 'Web Channel Handler : File upload failed!' });
+              abort = true;
+
+              return;
             }
-          } catch (err) {
-            this.logger.warn('Unable to upload file ', err);
-
-            return void res
-              .status(403)
-              .json({ err: 'Web Channel Handler : File upload failed!' });
           }
-        }
 
-        if (messageEvent.isSyncFromChatbot()) {
-          const thread = await this.sessionService.resolveThreadForHistory(
+          if (messageEvent.isSyncFromChatbot()) {
+            const thread = await this.sessionService.resolveThreadForHistory(
+              req,
+              profile.id,
+            );
+            if (!thread) {
+              res.status(409).json({
+                err: 'Web Channel Handler : No thread available before first user message',
+              });
+              abort = true;
+
+              return;
+            }
+            messageEvent.setThreadId(thread.id);
+            if (req.session.web) req.session.web.threadId = thread.id;
+
+            const sentMessage: MessageCreateDto = {
+              mid: messageEvent.getId(),
+              message: {
+                type: OutgoingMessageType.text,
+                data: { text: messageEvent.getText() },
+              },
+              recipient: profile.id,
+              thread: thread.id,
+              read: true,
+              delivery: true,
+            };
+            this.channelEventBus.emitSent(sentMessage, messageEvent);
+
+            return;
+          }
+
+          messageEvent.setMessageId(this.generateId());
+          if (profile.foreignId) {
+            messageEvent.setAuthorForeignId(profile.foreignId);
+          }
+          messageEvent.setCreatedAt(new Date());
+
+          // Resolve the thread before acknowledging the socket request so the
+          // client receives a stable thread_id, then dispatch chatbot work later.
+          const thread = await this.sessionService.resolveThreadForIncoming(
             req,
             profile.id,
-          );
-          if (!thread) {
-            return void res.status(409).json({
-              err: 'Web Channel Handler : No thread available before first user message',
-            });
-          }
-          messageEvent.setThreadId(thread.id);
-          if (req.session.web) req.session.web.threadId = thread.id;
-
-          const sentMessage: MessageCreateDto = {
-            mid: messageEvent.getId(),
-            message: {
-              type: OutgoingMessageType.text,
-              data: { text: messageEvent.getText() },
+            {
+              explicitThreadId: messageEvent.getThreadId(),
+              inactivityHours: this.sessionService.resolveInactivityHours(
+                source.settings,
+              ),
+              sourceId: source.id,
             },
-            recipient: profile.id,
-            thread: thread.id,
-            read: true,
-            delivery: true,
-          };
-          this.channelEventBus.emitSent(sentMessage, messageEvent);
-          continue;
+          );
+          messageEvent.setThreadId(thread.id);
+          messageEvent.setThreadIdOnRaw(thread.id);
+
+          this.broadcast(profile, StdEventType.message, messageEvent.getRaw());
+          this.enqueueMessageDispatch(req, messageEvent);
+
+          return;
         }
 
-        messageEvent.setMessageId(this.generateId());
-        if (profile.foreignId) {
-          messageEvent.setAuthorForeignId(profile.foreignId);
-        }
-        messageEvent.setCreatedAt(new Date());
-        // Resolve the thread before acknowledging the socket request so the
-        // client receives a stable thread_id, then dispatch chatbot work later.
-        const thread = await this.sessionService.resolveThreadForIncoming(
-          req,
-          profile.id,
-          {
-            explicitThreadId: messageEvent.getThreadId(),
-            inactivityHours: this.sessionService.resolveInactivityHours(
-              source.settings,
-            ),
-            sourceId: source.id,
-          },
-        );
-        messageEvent.setThreadId(thread.id);
-        messageEvent.setThreadIdOnRaw(thread.id);
+        const type = event.getEventType();
+        const threadId = event.getThreadId();
+        if (threadId) event.setThreadIdOnRaw(threadId);
+        this.broadcast(profile, type, event.getRaw());
+        this.channelEventBus.emitStatusEvent(event);
+      });
 
-        this.broadcast(profile, StdEventType.message, messageEvent.getRaw());
-        this.enqueueMessageDispatch(req, messageEvent);
-
-        continue;
-      }
-
-      const type = event.getEventType();
-      const threadId = event.getThreadId();
-      if (threadId) event.setThreadIdOnRaw(threadId);
-      this.broadcast(profile, type, event.getRaw());
-      this.channelEventBus.emitStatusEvent(event);
+      if (abort) return;
     }
 
     res.status(200).json(responseBody);

--- a/packages/api/src/helper/README.md
+++ b/packages/api/src/helper/README.md
@@ -1,3 +1,52 @@
+# Middleware helpers
+
+Middleware helpers form an onion-style chain that wraps the handling of every
+inbound channel event (user messages **and** status events: delivery, read,
+typing, echo, …) before it reaches the workflow engine. Use them to deduplicate
+provider redeliveries, rate limit a contact, merge consecutive messages,
+transcribe audio (Speech-to-Text), measure turn duration, etc.
+
+Unlike storage/RAG helpers (where a single "default" helper is selected), **all**
+registered middleware helpers run, ordered by `getPriority()` (lower runs first,
+outermost layer).
+
+## Contract
+
+A middleware helper extends `BaseMiddlewareHelper` and implements one onion
+method:
+
+```ts
+abstract handle(
+  event: ChannelInboundEvent,
+  next: InboundMiddlewareNext,
+): Promise<void>;
+```
+
+- Call `await next()` to let the event proceed — optionally after mutating it in
+  place (e.g. Speech-to-Text sets the transcript as text).
+- **Do not** call `next()` to drop the event (e.g. deduplicate redeliveries,
+  rate limit).
+- Wrap `await next()` in `try/catch` / `try/finally` to react to downstream
+  success or failure (e.g. roll back a claim, record metrics).
+
+A helper that only observes must guard its own errors and still call `next()`:
+a thrown error propagates to the transport, which logs it and abandons the
+event. Message-specific helpers should narrow on the type (e.g.
+`event instanceof MessageInboundEvent`) and pass other events straight through.
+
+## Interception point
+
+The chain is executed by each transport through
+`ChannelHandler.dispatchInboundEvent(event, next)`, which wraps **all
+post-decode processing** as `next`: subscriber resolution/creation, attachment
+persistence/uploads, thread resolution, socket broadcasts, and hook emission. A
+dropped event therefore incurs none of those side effects.
+
+> Channels that override `handle()` or dispatch events themselves (e.g. a
+> gateway/WebSocket channel that calls `ChannelEventBus` directly) must route
+> their inbound events through `dispatchInboundEvent` to participate in the
+> chain.
+
 # RAG helpers
 
 Hexabot ships with one built-in, database-owned RAG helper:

--- a/packages/api/src/helper/helper.module.ts
+++ b/packages/api/src/helper/helper.module.ts
@@ -14,6 +14,7 @@ import { UserModule } from '@/user/user.module';
 
 import { HelperController } from './helper.controller';
 import { HelperService } from './helper.service';
+import { InboundMiddlewareService } from './inbound-middleware.service';
 
 @Global()
 @InjectDynamicProviders(
@@ -29,7 +30,7 @@ import { HelperService } from './helper.service';
 @Module({
   imports: [HttpModule, CmsModule, ChatModule, UserModule],
   controllers: [HelperController],
-  providers: [HelperService],
-  exports: [HelperService],
+  providers: [HelperService, InboundMiddlewareService],
+  exports: [HelperService, InboundMiddlewareService],
 })
 export class HelperModule {}

--- a/packages/api/src/helper/inbound-middleware.service.spec.ts
+++ b/packages/api/src/helper/inbound-middleware.service.spec.ts
@@ -1,0 +1,133 @@
+/*
+ * Hexabot — Fair Core License (FCL-1.0-ALv2)
+ * Copyright (c) 2026 Hexastack.
+ * Full terms: see LICENSE.md.
+ */
+
+import { ChannelInboundEvent } from '@/channel/lib/inbound-events';
+
+import { HelperService } from './helper.service';
+import { InboundMiddlewareService } from './inbound-middleware.service';
+import {
+  BaseMiddlewareHelper,
+  InboundMiddlewareNext,
+} from './lib/base-middleware-helper';
+import { HelperType } from './types';
+
+/** Minimal middleware double driven by the provided `handle` callback. */
+const makeMiddleware = (
+  name: string,
+  priority: number,
+  handle: (
+    event: ChannelInboundEvent,
+    next: InboundMiddlewareNext,
+  ) => Promise<void>,
+): BaseMiddlewareHelper =>
+  ({
+    getName: () => name,
+    getType: () => HelperType.MIDDLEWARE,
+    getPriority: () => priority,
+    handle,
+  }) as unknown as BaseMiddlewareHelper;
+
+describe('InboundMiddlewareService', () => {
+  let service: InboundMiddlewareService;
+  let helperService: jest.Mocked<Pick<HelperService, 'getAllByType'>>;
+  const event = {} as ChannelInboundEvent;
+
+  beforeEach(() => {
+    helperService = { getAllByType: jest.fn() };
+    service = new InboundMiddlewareService(
+      helperService as unknown as HelperService,
+    );
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  it('runs middlewares in ascending priority order around next', async () => {
+    const calls: string[] = [];
+    const next = jest.fn(async () => {
+      calls.push('downstream');
+    });
+    helperService.getAllByType.mockReturnValue([
+      makeMiddleware('second', 10, async (_e, n) => {
+        calls.push('second:before');
+        await n();
+        calls.push('second:after');
+      }),
+      makeMiddleware('first', -10, async (_e, n) => {
+        calls.push('first:before');
+        await n();
+        calls.push('first:after');
+      }),
+    ] as any);
+
+    await service.run(event, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(calls).toEqual([
+      'first:before',
+      'second:before',
+      'downstream',
+      'second:after',
+      'first:after',
+    ]);
+  });
+
+  it('does not run downstream when a middleware drops (skips next)', async () => {
+    const next = jest.fn();
+    const laterHandle = jest.fn();
+    helperService.getAllByType.mockReturnValue([
+      makeMiddleware('dropper', 0, async () => {
+        // deliberately does not call next()
+      }),
+      makeMiddleware('later', 10, laterHandle as any),
+    ] as any);
+
+    await service.run(event, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(laterHandle).not.toHaveBeenCalled();
+  });
+
+  it('propagates a downstream failure to the wrapping middleware', async () => {
+    const next = jest.fn().mockRejectedValue(new Error('downstream boom'));
+    const seen: string[] = [];
+    helperService.getAllByType.mockReturnValue([
+      makeMiddleware('observer', 0, async (_e, n) => {
+        try {
+          await n();
+        } catch (err) {
+          seen.push((err as Error).message);
+          throw err;
+        }
+      }),
+    ] as any);
+
+    await expect(service.run(event, next)).rejects.toThrow('downstream boom');
+    expect(seen).toEqual(['downstream boom']);
+  });
+
+  it('throws when a middleware calls next() more than once', async () => {
+    const next = jest.fn().mockResolvedValue(undefined);
+    helperService.getAllByType.mockReturnValue([
+      makeMiddleware('double', 0, async (_e, n) => {
+        await n();
+        await n();
+      }),
+    ] as any);
+
+    await expect(service.run(event, next)).rejects.toThrow(
+      'called multiple times',
+    );
+  });
+
+  it('runs next once when no middleware is registered', async () => {
+    const next = jest.fn().mockResolvedValue(undefined);
+    helperService.getAllByType.mockReturnValue([] as any);
+
+    await service.run(event, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/api/src/helper/inbound-middleware.service.ts
+++ b/packages/api/src/helper/inbound-middleware.service.ts
@@ -1,0 +1,68 @@
+/*
+ * Hexabot — Fair Core License (FCL-1.0-ALv2)
+ * Copyright (c) 2026 Hexastack.
+ * Full terms: see LICENSE.md.
+ */
+
+import { Injectable } from '@nestjs/common';
+
+import type { ChannelInboundEvent } from '@/channel/lib/inbound-events/channel-inbound-event';
+
+import { HelperService } from './helper.service';
+import { InboundMiddlewareNext } from './lib/base-middleware-helper';
+import { HelperType } from './types';
+
+/**
+ * Composes the registered {@link HelperType.MIDDLEWARE} helpers into an
+ * onion-style chain around the handling of an inbound channel event.
+ *
+ * Invoked by the transports via `ChannelHandler.dispatchInboundEvent`, so the
+ * chain wraps all post-decode processing (subscriber resolution, uploads,
+ * thread resolution, broadcast, dispatch) uniformly for every channel (messages
+ * and status events), with that processing passed as the innermost `next`. A
+ * middleware that does not call `next()` drops the event; one that awaits
+ * `next()` observes downstream success or failure.
+ *
+ * Helpers run in ascending `getPriority()` order (outermost first). Errors are
+ * **not** swallowed — a throwing middleware (or downstream) propagates to the
+ * transport, which logs it and abandons the event; middleware that only observes
+ * must guard its own errors and still call `next()`.
+ */
+@Injectable()
+export class InboundMiddlewareService {
+  constructor(private readonly helperService: HelperService) {}
+
+  /**
+   * Runs the middleware chain around `next`.
+   *
+   * @param event - The inbound channel event (message or status).
+   * @param next - The dispatch to wrap (emit to the event's chatbot hook).
+   */
+  async run(
+    event: ChannelInboundEvent,
+    next: InboundMiddlewareNext,
+  ): Promise<void> {
+    const middlewares = this.helperService
+      .getAllByType(HelperType.MIDDLEWARE)
+      .sort((a, b) => a.getPriority() - b.getPriority());
+
+    let currentIndex = -1;
+    const invoke = async (index: number): Promise<void> => {
+      if (index <= currentIndex) {
+        throw new Error('Inbound middleware next() called multiple times');
+      }
+
+      currentIndex = index;
+      const middleware = middlewares[index];
+      if (!middleware) {
+        await next();
+
+        return;
+      }
+
+      await middleware.handle(event, () => invoke(index + 1));
+    };
+
+    await invoke(0);
+  }
+}

--- a/packages/api/src/helper/index.ts
+++ b/packages/api/src/helper/index.ts
@@ -10,7 +10,11 @@ export * from './helper.module';
 
 export * from './helper.service';
 
+export * from './inbound-middleware.service';
+
 export * from './lib/base-helper';
+
+export * from './lib/base-middleware-helper';
 
 export * from './lib/base-rag-helper';
 

--- a/packages/api/src/helper/lib/base-middleware-helper.ts
+++ b/packages/api/src/helper/lib/base-middleware-helper.ts
@@ -1,0 +1,87 @@
+/*
+ * Hexabot — Fair Core License (FCL-1.0-ALv2)
+ * Copyright (c) 2026 Hexastack.
+ * Full terms: see LICENSE.md.
+ */
+
+import type { ChannelInboundEvent } from '@/channel/lib/inbound-events/channel-inbound-event';
+
+import { HelperName, HelperType } from '../types';
+
+import BaseHelper from './base-helper';
+
+/**
+ * Runs the remainder of the middleware chain and, at its core, all post-decode
+ * processing of the event: subscriber resolution, attachment persistence and
+ * uploads, thread resolution, socket broadcasts, and emission to the event's
+ * chatbot hook (which drives the workflow engine for messages, or the relevant
+ * listeners for status events).
+ *
+ * Awaiting it lets a middleware observe downstream success (it resolves) or
+ * failure (it rejects) — enabling patterns such as committing a deduplication
+ * claim only after the event was handled, or measuring end-to-end turn
+ * duration.
+ */
+export type InboundMiddlewareNext = () => Promise<void>;
+
+/**
+ * Base class for **middleware** helpers — an onion-style chain of pluggable
+ * pre-processors that wrap the handling of every inbound channel event (user
+ * messages *and* status events: delivery, read, typing, echo, ...).
+ *
+ * The chain is executed by each transport through
+ * `ChannelHandler.dispatchInboundEvent(event, next)`, which wraps **all
+ * post-decode processing** as `next`. A middleware therefore runs before any
+ * side effect — subscriber resolution/creation, attachment uploads, thread
+ * resolution, broadcasts, and hook emission. Each helper receives the event and
+ * a `next` continuation:
+ *
+ * - call `await next()` to let the event proceed (optionally after mutating it
+ *   in place — e.g. Speech-to-Text sets the transcript as text);
+ * - **do not** call `next()` to drop the event (e.g. deduplicate provider
+ *   redeliveries, rate limit a contact) — none of the above side effects run;
+ * - wrap `await next()` in `try/catch`/`try/finally` to react to downstream
+ *   success or failure (e.g. roll back a dedup claim, record metrics).
+ *
+ * Helpers that are message-specific should narrow on the event type (e.g.
+ * `event instanceof MessageInboundEvent`) and pass other events straight
+ * through via `next()`.
+ *
+ * Unlike storage/RAG helpers (where a single "default" helper is selected), all
+ * registered middleware helpers participate, ordered by {@link getPriority}.
+ *
+ * A helper that throws propagates the error to the caller of the emit; a helper
+ * that only observes must guard its own errors and still call `next()`.
+ */
+export abstract class BaseMiddlewareHelper<
+  N extends HelperName = HelperName,
+> extends BaseHelper<N> {
+  protected readonly type: HelperType = HelperType.MIDDLEWARE;
+
+  constructor(name: N) {
+    super(name);
+  }
+
+  /**
+   * Execution order within the chain. Lower runs first (outermost onion layer).
+   * Defaults to `0`.
+   *
+   * Override to position a helper relative to others (e.g. deduplication before
+   * heavier transforms such as Speech-to-Text).
+   */
+  public getPriority(): number {
+    return 0;
+  }
+
+  /**
+   * Wrap the dispatch of an inbound channel event.
+   *
+   * @param event - The inbound event (message or status).
+   * @param next - Continuation that runs the rest of the chain and the actual
+   *   dispatch. Call it to proceed; omit it to drop the event.
+   */
+  abstract handle(
+    event: ChannelInboundEvent,
+    next: InboundMiddlewareNext,
+  ): Promise<void>;
+}

--- a/packages/api/src/helper/types.ts
+++ b/packages/api/src/helper/types.ts
@@ -7,6 +7,7 @@
 import { AnySetting, ExtensionSetting } from '@/setting/types';
 
 import BaseHelper from './lib/base-helper';
+import { BaseMiddlewareHelper } from './lib/base-middleware-helper';
 import { BaseRagHelper } from './lib/base-rag-helper';
 import { BaseStorageHelper } from './lib/base-storage-helper';
 
@@ -14,6 +15,7 @@ export enum HelperType {
   STORAGE = 'storage',
   RAG = 'rag',
   UTIL = 'util',
+  MIDDLEWARE = 'middleware',
 }
 
 export type HelperName = string;
@@ -22,6 +24,7 @@ interface HelperTypeMap {
   [HelperType.STORAGE]: BaseStorageHelper<HelperName>;
   [HelperType.RAG]: BaseRagHelper<HelperName>;
   [HelperType.UTIL]: BaseHelper;
+  [HelperType.MIDDLEWARE]: BaseMiddlewareHelper<HelperName>;
 }
 
 export type TypeOfHelper<T extends HelperType> = HelperTypeMap[T];


### PR DESCRIPTION
## What changed?

Adds a new middleware helper category: an onion-style chain that wraps the handling of every inbound channel event (messages and status events) before it reaches the workflow engine — for dedup, rate limiting, message merging, Speech-to-Text, turn timing, etc.

## What's included
- New helper type HelperType.MIDDLEWARE + BaseMiddlewareHelper with a single onion method handle(event, next): call next() to proceed (optionally mutating the event), omit it to drop, wrap it to observe success/failure. Ordered by getPriority(); all registered helpers run (helper/types.ts, helper/lib/base-middleware-helper.ts, helper/index.ts).
- Runner InboundMiddlewareService composes the chain and is exported from the global HelperModule (helper/inbound-middleware.service.ts).
- Interception boundary ChannelHandler.dispatchInboundEvent(event, next) wraps all post-decode processing — subscriber resolution, uploads, thread resolution, broadcasts, hook emission — so a dropped event incurs none of those side effects. 
- Wired into both transports (http-channel-handler.ts, base-web-channel.ts).
- Docs: middleware section in helper/README.md, boundary docs in channel/README.md, plus AGENTS.md/README.md entries.
## Tests
Onion ordering / drop / fail-open / double-next() (runner), and ordering specs proving a drop short-circuits before subscriber resolution, preprocessing, uploads, thread resolution, broadcasts, and hook emission (HTTP + web).

## Notes
- Concrete middleware helpers (e.g. deduplication) ship separately as hexabot-helper-* packages — none is bundled here.
- Channels that override handle() (Slack, Telegram, Discord) must route their dispatch through dispatchInboundEvent to participate; base-loop channels (Facebook, WhatsApp) and web get it automatically.
