### PR TITLE
fix(frontend): enable expression assist button in conditional and loop drawers

### DIFF
--- a/packages/frontend/src/components/visual-editor/v4/components/main/ConditionalDrawer/ConditionalFormDrawer.tsx
+++ b/packages/frontend/src/components/visual-editor/v4/components/main/ConditionalDrawer/ConditionalFormDrawer.tsx
@@ -137,6 +137,7 @@ const ConditionalFormDrawerContent = ({
               value={condition}
               onChange={(nextValue) => onConditionChange(index, nextValue)}
               helperText={conditionHelperText}
+              enableExpressionAssist
               fullWidth
             />
           </Box>

--- a/packages/frontend/src/components/visual-editor/v4/components/main/LoopDrawer/LoopFormDrawer.tsx
+++ b/packages/frontend/src/components/visual-editor/v4/components/main/LoopDrawer/LoopFormDrawer.tsx
@@ -233,6 +233,7 @@ const LoopFormDrawerContent = ({
                   errors.forEachIn ??
                   t("visual_editor.loop_drawer.form.for_each.in_helper")
                 }
+                enableExpressionAssist
                 fullWidth
               />
             </Box>
@@ -250,6 +251,7 @@ const LoopFormDrawerContent = ({
               errors.whileCondition ??
               t("visual_editor.loop_drawer.form.while.helper")
             }
+            enableExpressionAssist
             fullWidth
           />
         </Box>
@@ -290,6 +292,7 @@ const LoopFormDrawerContent = ({
             helperText={
               errors.until ?? t("visual_editor.loop_drawer.form.until.helper")
             }
+            enableExpressionAssist
             fullWidth
           />
         </Box>
@@ -354,6 +357,7 @@ const LoopFormDrawerContent = ({
                   errors.accumulateMerge ??
                   t("visual_editor.loop_drawer.form.accumulate.merge_helper")
                 }
+                enableExpressionAssist
                 fullWidth
               />
             </Box>


### PR DESCRIPTION
## Summary
Fixed the "Dynamic value" (Σ) button in the Conditional and Loop step drawers, which was rendered as a static, non-interactive icon instead of the clickable expression-assist control. `JsonataFormulaField` now receives `enableExpressionAssist` in `ConditionalFormDrawer.tsx` and in all four JSONata fields of `LoopFormDrawer.tsx` (`forEachIn`, `whileCondition`, `until`, `accumulateMerge`).

## Why
`JsonataFormulaField` only renders the real `ExpressionAssist` button (with its `onClick` and expression menu) when `enableExpressionAssist` is passed; otherwise it falls back to a decorative `Box` with the same icon and tooltip but no handler. These two drawers never passed the prop, so users saw a Σ icon that looked clickable but did nothing — while other consumers like `JsonataTextWidget.tsx` already worked correctly.

## How to review
- [`ConditionalFormDrawer.tsx`](packages/frontend/src/components/visual-editor/v4/components/main/ConditionalDrawer/ConditionalFormDrawer.tsx) — single `JsonataFormulaField` usage for each condition.
- [`LoopFormDrawer.tsx`](packages/frontend/src/components/visual-editor/v4/components/main/LoopDrawer/LoopFormDrawer.tsx) — four `JsonataFormulaField` usages (for-each, while, until, accumulate-merge).
- Compare against the working reference implementation in [`JsonataTextWidget.tsx`](packages/frontend/src/app-components/inputs/JsonSchemaForm/widgets/JsonataTextWidget.tsx) to confirm the prop is used consistently.

## Validation
- Traced the rendering logic in `JsonataFormulaField.tsx` to confirm `showAssistIcon`/`showModeIcon` branch and that the fallback `Box` has no `onClick`.
- Verified no other drawer/component using `JsonataFormulaField` was missing the prop.
- Manual/visual confirmation still recommended: open a Conditional step and a Loop step (for-each and while modes) in the flow editor and confirm the Σ button opens the expression-assist menu.
