### PR TITLE
fix(types): swap manual and scheduled workflow type order

### DIFF
--- a/packages/types/src/workflow/domain.ts
+++ b/packages/types/src/workflow/domain.ts
@@ -8,8 +8,8 @@ import { z } from "zod";
 
 export enum WorkflowType {
   conversational = "conversational",
-  manual = "manual",
   scheduled = "scheduled",
+  manual = "manual",
 }
 
 export enum WorkflowVersionAction {


### PR DESCRIPTION
## Screenshots
- After the update
<img width="1510" height="876" alt="image" src="https://github.com/user-attachments/assets/ea374e51-693b-42af-8691-fc1b1c9fb24f" />

- Before the update  
<img width="1510" height="876" alt="image" src="https://github.com/user-attachments/assets/3f9eb236-9b64-4573-b3df-b47529b36c87" />

## Summary
Reordered the workflow type options so **Scheduled** appears before **Manual**.

## Why
This aligns the workflow editor with the desired option order.

## How to review
Confirm the workflow type selector displays the options in this order:
1. Conversational
2. Scheduled
3. Manual

Verify that selecting each option still works as expected.

## Validation
- Reviewed the scoped frontend change.
- Automated checks were not completed.