### PR TITLE
refactor(frontend): wire password confirmation via RHF deps

### DIFF
--- a/packages/frontend/src/app-components/auth/ResetPassword.tsx
+++ b/packages/frontend/src/app-components/auth/ResetPassword.tsx
@@ -11,7 +11,7 @@ import {
   Key as KeyIcon,
   Repeat2,
 } from "lucide-react";
-import { useForm } from "react-hook-form";
+import { RegisterOptions, useForm } from "react-hook-form";
 import { Link as RouterLink } from "react-router";
 
 import { useApiClientMutation } from "@/hooks/useApiClient";
@@ -39,7 +39,8 @@ export const ResetPassword = () => {
     password: {
       ...rules.password,
       required: t("message.password_is_required"),
-    },
+      deps: ["password2"],
+    } satisfies RegisterOptions<ResetPasswordAttributes, "password">,
     password2: {
       ...rules.password2,
       required: t("message.password_is_required"),

--- a/packages/frontend/src/components/profile/profile.tsx
+++ b/packages/frontend/src/components/profile/profile.tsx
@@ -8,7 +8,7 @@ import { Button, MenuItem, TextField, Typography } from "@mui/material";
 import Grid from "@mui/material/Grid";
 import { Check, Key, Languages, Mail } from "lucide-react";
 import { FC, useEffect, useMemo } from "react";
-import { Controller, useForm } from "react-hook-form";
+import { Controller, RegisterOptions, useForm } from "react-hook-form";
 
 import { ContentContainer, ContentItem } from "@/app-components/dialogs";
 import { Adornment } from "@/app-components/inputs/Adornment";
@@ -52,8 +52,6 @@ export const ProfileForm: FC<ProfileFormProps> = ({
     [user],
   );
   const {
-    watch,
-    trigger,
     handleSubmit,
     control,
     formState: { errors },
@@ -72,16 +70,12 @@ export const ProfileForm: FC<ProfileFormProps> = ({
     },
     password: {
       ...rules.password,
-    },
+      deps: ["password2"],
+    } satisfies RegisterOptions<IProfileAttributes, "password">,
     password2: {
-      validate: (val?: string) => {
-        if (val !== watch("password")) {
-          trigger("password");
-
-          return t("message.password_match");
-        }
-      },
-    },
+      validate: (value, { password }) =>
+        value === password || t("message.password_match"),
+    } satisfies RegisterOptions<IProfileAttributes, "password2">,
   };
   const onSubmitForm = ({
     password,

--- a/packages/frontend/src/components/users/CreateUserForm.tsx
+++ b/packages/frontend/src/components/users/CreateUserForm.tsx
@@ -8,7 +8,7 @@ import type { Role } from "@hexabot-ai/types";
 import { Button, Link, TextField } from "@mui/material";
 import Grid from "@mui/material/Grid";
 import { FC, Fragment } from "react";
-import { Controller, useForm } from "react-hook-form";
+import { Controller, RegisterOptions, useForm } from "react-hook-form";
 
 import { ContentContainer, ContentItem } from "@/app-components/dialogs";
 import AutoCompleteEntitySelect from "@/app-components/inputs/AutoCompleteEntitySelect";
@@ -68,8 +68,6 @@ export const CreateUserForm: FC<ComponentFormProps<undefined>> = ({
   const {
     control,
     register,
-    watch,
-    trigger,
     formState: { errors },
     handleSubmit,
   } = useForm<CreateUserFormData>({
@@ -97,16 +95,12 @@ export const CreateUserForm: FC<ComponentFormProps<undefined>> = ({
     password: {
       ...rules.password,
       required: t("message.password_is_required"),
-    },
+      deps: ["password2"],
+    } satisfies RegisterOptions<CreateUserFormData, "password">,
     password2: {
-      validate: (value?: string) => {
-        if (value !== watch("password")) {
-          trigger("password");
-
-          return t("message.password_match");
-        }
-      },
-    },
+      validate: (value, { password }) =>
+        value === password || t("message.password_match"),
+    } satisfies RegisterOptions<CreateUserFormData, "password2">,
   };
   const onSubmitForm = ({
     password2: _password2,


### PR DESCRIPTION
## Summary

Replaces the imperative `watch()` / `trigger()` password-confirmation wiring in `CreateUserForm`, `ProfileForm`, and `ResetPassword` with React Hook Form's native `deps` option. The `password` field now declares `deps: ["password2"]`, and `password2.validate` reads the `formValues` argument RHF already passes instead of calling `watch("password")`.

Closes #1060

## Why

The three forms each hand-rolled cross-field revalidation: `password2.validate` compared against `watch("password")` and called `trigger("password")` as a side effect. That coupled validation to imperative calls inside a validator, and it wired the dependency backwards — editing the `password` field left a stale "passwords must match" error on `password2` until that second field was touched again. RHF supports this declaratively via `deps`, so the workaround is no longer needed.

## How to review

- **`packages/frontend/src/components/users/CreateUserForm.tsx`**, **`src/components/profile/profile.tsx`** — the substantive changes: `deps` added to the `password` rule, `password2.validate` switched to `(value, { password }) => …`, and `watch` / `trigger` dropped from the `useForm` destructuring.
- **`packages/frontend/src/app-components/auth/ResetPassword.tsx`** — one line; its `password2` rule already came from `useValidationRules` and compared against `values.password`, so it only needed `deps`.
- **The `satisfies RegisterOptions<FormType, "field">` annotations** are load-bearing, not decoration. Without a contextual type, `["password2"]` widens to `string[]`, which isn't assignable to RHF's `FieldPath<T>[]`. It also type-checks the dep name against the form's real fields and gives `validate` typed parameters, which let the explicit `value?: string` annotations go.

Two deliberate non-changes worth a look:

- **`useValidationRules` is untouched.** `rules.password` is shared with `Login.tsx`, which has no `password2` field, so `deps` belongs per-form rather than in the shared hook.
- **`password2` in the two forms above was not switched to the shared `rules.password2`.** That rule carries a `minLength: 8` these forms don't currently apply — it would change the error message on short input, and in the profile form (where the password is optional) risk a min-length error on an untouched empty field.

## Validation

- `typecheck`, `eslint`, and `prettier --check` clean on all three files.
- Full frontend suite passes: 40 files, 232 tests.
- Drove RHF headlessly via `createFormControl` with the exact rule shapes from each form to confirm validation semantics are unchanged: mismatch is flagged on submit, matching values submit cleanly, and empty/empty passes (the optional profile-password case). Also confirmed the new behavior — after a failed submit, editing *only* the password field clears and re-raises `password2`'s error. That probe required poking internals (`_formState.isSubmitted`, which only `useForm`'s React subscriber sets), so it was throwaway and is not in the diff; the frontend has no DOM test environment to host a real form test (`environment: "node"`, no testing-library/jsdom).

