### PR TITLE
feat(ai): add OrcaRouter as a named model provider

### DIFF
--- a/packages/api/src/extensions/actions/ai/ai-base.action.spec.ts
+++ b/packages/api/src/extensions/actions/ai/ai-base.action.spec.ts
@@ -271,6 +271,7 @@ describe('AiBaseAction', () => {
       expect(action.shouldRequireApiKeyPublic('openai')).toBe(true);
       expect(action.shouldRequireApiKeyPublic('gateway')).toBe(true);
       expect(action.shouldRequireApiKeyPublic('litellm')).toBe(true);
+      expect(action.shouldRequireApiKeyPublic('orcarouter')).toBe(true);
     });
 
     it('allows local providers without api key', () => {
@@ -321,6 +322,41 @@ describe('AiBaseAction', () => {
         ...options,
         name: 'litellm',
         baseURL: options.baseURL,
+      });
+      expect(result).toBe(provider);
+    });
+
+    it('loads orcarouter provider via createOpenAICompatible with default gateway URL', async () => {
+      const provider = createProviderStub();
+
+      (createOpenAICompatible as jest.Mock).mockReturnValue(provider);
+
+      const result = await action.loadProviderPublic('orcarouter', {
+        apiKey: 'sk-orca-key',
+      });
+
+      expect(createOpenAICompatible).toHaveBeenCalledWith({
+        apiKey: 'sk-orca-key',
+        name: 'orcarouter',
+        baseURL: 'https://api.orcarouter.ai/v1',
+      });
+      expect(result).toBe(provider);
+    });
+
+    it('loads orcarouter provider with an explicit base URL override', async () => {
+      const provider = createProviderStub();
+
+      (createOpenAICompatible as jest.Mock).mockReturnValue(provider);
+
+      const result = await action.loadProviderPublic('orcarouter', {
+        apiKey: 'sk-orca-key',
+        baseURL: 'https://my-orca-proxy.example/v1',
+      });
+
+      expect(createOpenAICompatible).toHaveBeenCalledWith({
+        apiKey: 'sk-orca-key',
+        name: 'orcarouter',
+        baseURL: 'https://my-orca-proxy.example/v1',
       });
       expect(result).toBe(provider);
     });

--- a/packages/api/src/extensions/actions/ai/ai-base.action.ts
+++ b/packages/api/src/extensions/actions/ai/ai-base.action.ts
@@ -118,7 +118,8 @@ export abstract class AiBaseAction<
     return (
       providerId === 'openai' ||
       providerId === 'gateway' ||
-      providerId === 'litellm'
+      providerId === 'litellm' ||
+      providerId === 'orcarouter'
     );
   }
 
@@ -150,6 +151,14 @@ export abstract class AiBaseAction<
         ...options,
         name: providerId,
         baseURL: options.baseURL,
+      });
+    }
+
+    if (providerId === 'orcarouter') {
+      return createOpenAICompatible({
+        ...options,
+        name: 'orcarouter',
+        baseURL: options.baseURL ?? 'https://api.orcarouter.ai/v1',
       });
     }
 

--- a/packages/api/src/extensions/actions/ai/ai-schemas.spec.ts
+++ b/packages/api/src/extensions/actions/ai/ai-schemas.spec.ts
@@ -238,6 +238,27 @@ describe('ai model binding schema', () => {
       result.error?.issues.some((issue) => issue.path[0] === 'model_id'),
     ).toBe(true);
   });
+
+  it('accepts the named orcarouter provider with a model id', () => {
+    const result = aiModelBindingSchema.safeParse({
+      provider: 'orcarouter',
+      model_id: 'orcarouter/auto',
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.data?.provider).toBe('orcarouter');
+  });
+
+  it('accepts orcarouter with an explicit base URL', () => {
+    const result = aiModelBindingSchema.safeParse({
+      provider: 'orcarouter',
+      model_id: 'orcarouter/auto',
+      base_url: 'https://my-orca-proxy.example/v1',
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.data?.base_url).toBe('https://my-orca-proxy.example/v1');
+  });
 });
 
 describe('legacy provider/model settings rejection', () => {

--- a/packages/api/src/extensions/actions/ai/model.binding.ts
+++ b/packages/api/src/extensions/actions/ai/model.binding.ts
@@ -46,7 +46,7 @@ export const aiModelBindingSchema = z.strictObject({
       'ui:options': {
         showWhen: {
           field: 'provider',
-          in: ['gateway', 'litellm', 'openai-compatible'],
+          in: ['gateway', 'litellm', 'openai-compatible', 'orcarouter'],
         },
       },
     }),
@@ -70,7 +70,7 @@ export const aiModelBindingSchema = z.strictObject({
       'ui:options': {
         showWhen: {
           field: 'provider',
-          in: ['gateway', 'litellm', 'openai-compatible'],
+          in: ['gateway', 'litellm', 'openai-compatible', 'orcarouter'],
         },
         hideUntilAdded: true,
       },

--- a/packages/api/src/extensions/actions/ai/provider.constants.ts
+++ b/packages/api/src/extensions/actions/ai/provider.constants.ts
@@ -39,6 +39,7 @@ export const vercelAiSdkProviders = [
   'open-responses',
   'openai',
   'openai-compatible',
+  'orcarouter',
   'perplexity',
   'prodia',
   'replicate',


### PR DESCRIPTION
## What changed?

**Summary:** Add OrcaRouter as a named model provider in the AI model binding registry. The new `orcarouter` provider routes through the Vercel AI SDK OpenAI-compatible client to the [OrcaRouter](https://www.orcarouter.ai) gateway at `https://api.orcarouter.ai/v1` (overridable via `bindings.model.<def>.settings.base_url`).

[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible gateway that fronts a catalog of frontier and open-weight models behind a single endpoint. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

**Why:** Hexabot already supports several hosted gateways (`openai`, `gateway`, `litellm`). `orcarouter` fits the same pattern and gives users a first-class option to consume OrcaRouter's model catalog through the existing model binding editor.

**How to review:** The change is localized to the AI action extension:
- `provider.constants.ts` — registers `orcarouter` in `vercelAiSdkProviders`
- `model.binding.ts` — surfaces Base URL / Supports Structured Outputs fields for `orcarouter`
- `ai-base.action.ts` — `loadProvider` resolves `orcarouter` via `createOpenAICompatible` with default `base_url https://api.orcarouter.ai/v1`; `shouldRequireApiKey` enforces an API key
- Unit tests added for schema parsing and provider loading (default + explicit base URL)

**Validation:**
- `pnpm typecheck` — 7/7 packages green
- `pnpm lint` — 7/7 packages green
- `pnpm test` — 12/12 tasks green (api: 177 suites passed, 1238 tests passed)
- `pnpm build` — 7/7 packages green
- Live: a real completion through the new `orcarouter` provider path against `https://api.orcarouter.ai/v1` returned `ORCA-OK`

Disclosure: I'm an engineer on the OrcaRouter team.
